### PR TITLE
Exclude spec/test files from SonarCloud duplication check #21

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,7 @@ sonar.coverage.exclusions=**/*
 sonar.exclusions=.claude/**,scripts/**
 
 # Files to exclude from the duplicate check
-# sonar.cpd.exclusions=**/src/lib/data/questions.ts,**/src/lib/data/phrases/**/*.ts
+sonar.cpd.exclusions=**/*.spec.ts,**/*.spec.svelte.ts,**/*.test.ts
 
 # Use SonarCloud-compatible tsconfig
 sonar.typescript.tsconfigPath=tsconfig.sonar.json


### PR DESCRIPTION
## Summary

- Add `sonar.cpd.exclusions` to `sonar-project.properties` to exclude `*.spec.ts`, `*.spec.svelte.ts`, and `*.test.ts` from SonarCloud's duplication check

## Background

PR #20 failed the SonarCloud quality gate with 3.5% duplication (threshold ≤3%). The duplication was flagged in test files (`GameScene.svelte.spec.ts`, `VirtualJoystick.svelte.spec.ts`, `input.svelte.spec.ts`) which have inherently repetitive setup patterns. Excluding test files from CPD is standard practice.

closes #21