### PR TITLE
Add CRT-aware font helpers (get_active_font / get_active_font_size_multiplier) so consumers cannot forget to wire CRT state #140

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.53.0",
+	"version": "0.54.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/lib/game-kit/display/ScoreDisplay.svelte
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { T, useTask } from '@threlte/core'
 	import { Text } from '@threlte/extras'
-	import { crt } from '$lib/game-kit/crt.svelte'
 	import { get_hi_value_color } from '$lib/game-kit/display/score-display-color'
 	import {
 		ANIM_DURATION_MS,
@@ -88,10 +87,9 @@
 
 	useTask(tick)
 
-	// Font is driven by CRT state, independent of is_alt (CYBER) palette.
-	let should_use_alt_font = $derived(!crt.is_crt_enabled)
-	let current_font = $derived(fonts.get_font(should_use_alt_font))
-	let font_size_multiplier = $derived(fonts.get_font_size_multiplier(should_use_alt_font))
+	// Font is driven by CRT state via fonts.get_active_*; is_alt only drives the palette.
+	let current_font = $derived(fonts.get_active_font())
+	let font_size_multiplier = $derived(fonts.get_active_font_size_multiplier())
 	let panel_color = $derived(is_alt ? CYBER_PANEL_COLOR : RETRO_PANEL_COLOR)
 	let panel_emissive = $derived(is_alt ? CYBER_PANEL_EMISSIVE : RETRO_PANEL_EMISSIVE)
 	let panel_emissive_intensity = $derived(

--- a/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
@@ -9,8 +9,8 @@ vi.mock('@threlte/core', () => ({ T: {}, useTask: vi.fn() }))
 vi.mock('@threlte/extras', () => ({ Text: {} }))
 vi.mock('$lib/game-kit/fonts', () => ({
 	fonts: {
-		get_font: vi.fn(() => 'sans'),
-		get_font_size_multiplier: vi.fn(() => 1),
+		get_active_font: vi.fn(() => 'sans'),
+		get_active_font_size_multiplier: vi.fn(() => 1),
 	},
 }))
 
@@ -77,38 +77,41 @@ describe('ScoreDisplay', () => {
 	})
 })
 
-describe('ScoreDisplay font selection — driven by CRT, not CYBER (is_alt)', () => {
-	it('derives should_use_alt_font from !crt.is_crt_enabled (font swaps with CRT, not CYBER)', () => {
+describe('ScoreDisplay font selection — driven by CRT-aware fonts helpers, not by is_alt (CYBER)', () => {
+	it('current_font uses fonts.get_active_font() (no caller-supplied flag)', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/,
+			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_active_font\(\s*\)\s*\)/,
 		)
 	})
 
-	it('current_font passes should_use_alt_font into fonts.get_font (not is_alt)', () => {
+	it('font_size_multiplier uses fonts.get_active_font_size_multiplier()', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/,
+			/let\s+font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_active_font_size_multiplier\(\s*\)\s*\)/,
 		)
 	})
 
-	it('font_size_multiplier passes should_use_alt_font into fonts.get_font_size_multiplier', () => {
-		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)\s*\)/,
-		)
+	it('no longer derives a local should_use_alt_font (CRT awareness lives in fonts.ts)', () => {
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/\bshould_use_alt_font\b/)
 	})
 
-	it('imports crt from $lib/game-kit/crt.svelte', () => {
-		expect(SCORE_DISPLAY_SOURCE).toMatch(
+	it('no longer imports crt directly (consumer is decoupled from CRT module)', () => {
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(
 			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/,
 		)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/\bcrt\.is_crt_enabled\b/)
 	})
 
 	it('keeps is_alt prop driving palette decisions (panel/label/value colors)', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(/let\s+panel_color\s*=\s*\$derived\(\s*is_alt\s*\?/)
 	})
 
-	it('does not pass is_alt directly into fonts helpers', () => {
+	it('does not pass is_alt into any fonts helper (font axis is CRT, not CYBER)', () => {
 		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
 		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_active_font\(\s*is_alt\s*\)/)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(
+			/fonts\.get_active_font_size_multiplier\(\s*is_alt\s*\)/,
+		)
 	})
 })
 

--- a/src/lib/game-kit/fonts.test.ts
+++ b/src/lib/game-kit/fonts.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { crt } from './crt.svelte'
 import { fonts } from './fonts'
+
+const RETRO_MULTIPLIER = 0.8
+const ALT_MULTIPLIER = 1
 
 describe('fonts', () => {
 	it('get_font returns different fonts for retro (false) vs alt (true) selection', () => {
@@ -28,11 +32,11 @@ describe('fonts', () => {
 	})
 
 	it('get_font_size_multiplier returns 0.8 for retro selection', () => {
-		expect(fonts.get_font_size_multiplier(false)).toBe(0.8)
+		expect(fonts.get_font_size_multiplier(false)).toBe(RETRO_MULTIPLIER)
 	})
 
 	it('get_font_size_multiplier returns 1 for alt selection', () => {
-		expect(fonts.get_font_size_multiplier(true)).toBe(1)
+		expect(fonts.get_font_size_multiplier(true)).toBe(ALT_MULTIPLIER)
 	})
 
 	it('get_font_size_multiplier returns higher value for alt selection', () => {
@@ -48,5 +52,48 @@ describe('fonts', () => {
 	it('get_font_family returns consistent value for same input', () => {
 		expect(fonts.get_font_family(false)).toBe(fonts.get_font_family(false))
 		expect(fonts.get_font_family(true)).toBe(fonts.get_font_family(true))
+	})
+})
+
+describe('fonts CRT-aware helpers — driven by crt.is_crt_enabled, not by caller-supplied flag', () => {
+	// crt is a singleton; ensure each test starts from the default enabled state
+	// and restore it afterwards so other tests are not affected.
+	beforeEach(() => {
+		if (!crt.is_crt_enabled) crt.toggle()
+	})
+
+	afterEach(() => {
+		if (!crt.is_crt_enabled) crt.toggle()
+	})
+
+	it('get_active_font returns the dot (PressStart2P) font when CRT is enabled', () => {
+		expect(crt.is_crt_enabled).toBe(true)
+		expect(fonts.get_active_font()).toContain('PressStart2P')
+		expect(fonts.get_active_font()).toBe(fonts.get_font(false))
+	})
+
+	it('get_active_font returns the alt (Orbitron) font when CRT is disabled', () => {
+		crt.toggle()
+		expect(crt.is_crt_enabled).toBe(false)
+		expect(fonts.get_active_font()).toContain('Orbitron')
+		expect(fonts.get_active_font()).toBe(fonts.get_font(true))
+	})
+
+	it('get_active_font_size_multiplier returns 0.8 when CRT is enabled', () => {
+		expect(crt.is_crt_enabled).toBe(true)
+		expect(fonts.get_active_font_size_multiplier()).toBe(RETRO_MULTIPLIER)
+	})
+
+	it('get_active_font_size_multiplier returns 1 when CRT is disabled', () => {
+		crt.toggle()
+		expect(crt.is_crt_enabled).toBe(false)
+		expect(fonts.get_active_font_size_multiplier()).toBe(ALT_MULTIPLIER)
+	})
+
+	it('get_active_font tracks CRT state across toggles (no stale capture)', () => {
+		const initial = fonts.get_active_font()
+		crt.toggle()
+		const toggled = fonts.get_active_font()
+		expect(toggled).not.toBe(initial)
 	})
 })

--- a/src/lib/game-kit/fonts.ts
+++ b/src/lib/game-kit/fonts.ts
@@ -1,3 +1,5 @@
+import { crt } from './crt.svelte'
+
 const FONT_RETRO = '/fonts/PressStart2P.ttf'
 const FONT_ALT = '/fonts/Orbitron.ttf'
 const FONT_FAMILY_RETRO = 'PressStart2P'
@@ -17,8 +19,19 @@ function get_font_size_multiplier(should_use_alt_font: boolean): number {
 	return should_use_alt_font ? ALT_FONT_SIZE_MULTIPLIER : RETRO_FONT_SIZE_MULTIPLIER
 }
 
+// CRT-aware variants: caller does not thread is_crt_enabled, avoiding wrong-axis bugs.
+function get_active_font(): string {
+	return get_font(!crt.is_crt_enabled)
+}
+
+function get_active_font_size_multiplier(): number {
+	return get_font_size_multiplier(!crt.is_crt_enabled)
+}
+
 export const fonts = {
 	get_font,
 	get_font_family,
 	get_font_size_multiplier,
+	get_active_font,
+	get_active_font_size_multiplier,
 }


### PR DESCRIPTION
closes #140