### PR TITLE
PR-2 of strict eslint migration: enforce require-unicode-regexp (add `u` flag to all regex literals) #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,8 +48,6 @@ const PR1_TEMPORARY_RULE_DISABLES = {
 	'@typescript-eslint/no-unnecessary-condition': 'off',
 	// TODO #188 follow-up: initialize all declared variables
 	'init-declarations': 'off',
-	// TODO #188 follow-up: add `u` flag to all regex literals (auto-fix skipped due to parser errors in test files)
-	'require-unicode-regexp': 'off',
 	// TODO #188 follow-up: tighten template-literal expression types
 	'@typescript-eslint/restrict-template-expressions': 'off',
 	// TODO #188 follow-up: add explicit return types at module boundaries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.78.0",
+	"version": "0.79.0",
 	"keywords": [
 		"svelte"
 	],
@@ -44,7 +44,7 @@
 		"@eslint/compat": "^2.1.0",
 		"@eslint/js": "^10.0.1",
 		"@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-		"@joshuafolkken/kit": "0.182.0",
+		"@joshuafolkken/kit": "0.184.0",
 		"@playwright/test": "1.60.0",
 		"@size-limit/file": "^12.1.0",
 		"@sveltejs/adapter-cloudflare": "^7.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,8 @@ importers:
         specifier: ^4.7.1
         version: 4.7.1(prettier@3.8.3)
       '@joshuafolkken/kit':
-        specifier: 0.182.0
-        version: 0.182.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@6.0.3)
+        specifier: 0.184.0
+        version: 0.184.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@6.0.3)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -1722,8 +1722,8 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
-  '@joshuafolkken/kit@0.182.0':
-    resolution: {integrity: sha512-VyO0PhEiBg6fvKNPFOIbfqB4PubR47uX6c5tMyPLVIMSFT/7mHzetxE6PlsgPru2niFDrEWtOhwkSNKu5SWW4w==, tarball: https://npm.pkg.github.com/download/@joshuafolkken/kit/0.182.0/0f4b9e6f71886c391abc3888627d7b7b286b8cce}
+  '@joshuafolkken/kit@0.184.0':
+    resolution: {integrity: sha512-sQHwnJmPn6YFWDAMdwKi7pziVQYMXVcojY4RKc1FV1kH8KT7fEsXmANmg30pJ5YuviYIGWJR6Jkfmtm/AF0dcQ==, tarball: https://npm.pkg.github.com/download/@joshuafolkken/kit/0.184.0/262d4a590a0a538bfad2efd73c927eb1be39122e}
     engines: {node: '>=22.19.0'}
     hasBin: true
     peerDependencies:
@@ -6010,7 +6010,7 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshuafolkken/kit@0.182.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@6.0.3)':
+  '@joshuafolkken/kit@0.184.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.59.4(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@6.0.3)':
     dependencies:
       '@eslint/compat': 2.1.0(eslint@10.4.0(jiti@2.7.0))
       '@eslint/js': 10.0.1(eslint@10.4.0(jiti@2.7.0))

--- a/src/lib/game-kit/CrtChromaticFilter.svelte.test.ts
+++ b/src/lib/game-kit/CrtChromaticFilter.svelte.test.ts
@@ -5,7 +5,7 @@ import CRT_CHROMATIC_FILTER_SOURCE from './CrtChromaticFilter.svelte?raw'
 
 describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 	it('declares an SVG <filter id="crt-chromatic"> in the markup', () => {
-		expect(CRT_CHROMATIC_FILTER_SOURCE).toMatch(/<filter\s+id="crt-chromatic"/)
+		expect(CRT_CHROMATIC_FILTER_SOURCE).toMatch(/<filter\s+id="crt-chromatic"/u)
 	})
 
 	it('isolates R / G / B with three feColorMatrix nodes and offsets R + B (G unchanged)', () => {
@@ -13,8 +13,9 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 		// (one per channel) and exactly two feOffset nodes (R outward, B opposite) is
 		// the structural shape of the effect — one matrix or one offset would mean a
 		// regression to a single-channel tint or to a uniform shift.
-		const color_matrix_count = (CRT_CHROMATIC_FILTER_SOURCE.match(/<feColorMatrix\b/g) ?? []).length
-		const offset_count = (CRT_CHROMATIC_FILTER_SOURCE.match(/<feOffset\b/g) ?? []).length
+		const color_matrix_count = (CRT_CHROMATIC_FILTER_SOURCE.match(/<feColorMatrix\b/gu) ?? [])
+			.length
+		const offset_count = (CRT_CHROMATIC_FILTER_SOURCE.match(/<feOffset\b/gu) ?? []).length
 		const REQUIRED_CHANNEL_MATRICES = 3
 		const REQUIRED_OFFSETS = 2
 		expect(color_matrix_count).toBe(REQUIRED_CHANNEL_MATRICES)
@@ -29,10 +30,10 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 		// the same horizontal amount — is what actually defines the effect, so assert
 		// that instead.
 		const r_match = CRT_CHROMATIC_FILTER_SOURCE.match(
-			/<feOffset[^>]*\sin="r_only"[^>]*\sdx="(-?\d+(?:\.\d+)?)"[^>]*\sdy="0"/,
+			/<feOffset[^>]*\sin="r_only"[^>]*\sdx="(-?\d+(?:\.\d+)?)"[^>]*\sdy="0"/u,
 		)
 		const b_match = CRT_CHROMATIC_FILTER_SOURCE.match(
-			/<feOffset[^>]*\sin="b_only"[^>]*\sdx="(-?\d+(?:\.\d+)?)"[^>]*\sdy="0"/,
+			/<feOffset[^>]*\sin="b_only"[^>]*\sdx="(-?\d+(?:\.\d+)?)"[^>]*\sdy="0"/u,
 		)
 		expect(r_match).toBeTruthy()
 		expect(b_match).toBeTruthy()
@@ -52,11 +53,11 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 		// the only mode that re-merges channel-isolated layers without losing information
 		// (default `over` would let the top layer's transparent pixels punch holes).
 		const composite_count = (
-			CRT_CHROMATIC_FILTER_SOURCE.match(/<feComposite[^>]*operator="arithmetic"/g) ?? []
+			CRT_CHROMATIC_FILTER_SOURCE.match(/<feComposite[^>]*operator="arithmetic"/gu) ?? []
 		).length
 		const REQUIRED_COMPOSITES = 2
 		expect(composite_count).toBe(REQUIRED_COMPOSITES)
-		expect(CRT_CHROMATIC_FILTER_SOURCE).toMatch(/k1="0"\s+k2="1"\s+k3="1"\s+k4="0"/)
+		expect(CRT_CHROMATIC_FILTER_SOURCE).toMatch(/k1="0"\s+k2="1"\s+k3="1"\s+k4="0"/u)
 	})
 
 	it('renders the SVG <filter id="crt-chromatic"> into the DOM when mounted standalone', () => {

--- a/src/lib/game-kit/CrtDitherPass.svelte.test.ts
+++ b/src/lib/game-kit/CrtDitherPass.svelte.test.ts
@@ -9,21 +9,21 @@ import CRT_DITHER_PASS_SOURCE from './CrtDitherPass.svelte?raw'
 describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 	it('imports EffectComposer / RenderPass / ShaderPass / OutputPass from three/examples', () => {
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/from\s+'three\/examples\/jsm\/postprocessing\/EffectComposer\.js'/,
+			/from\s+'three\/examples\/jsm\/postprocessing\/EffectComposer\.js'/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/from\s+'three\/examples\/jsm\/postprocessing\/RenderPass\.js'/,
+			/from\s+'three\/examples\/jsm\/postprocessing\/RenderPass\.js'/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/from\s+'three\/examples\/jsm\/postprocessing\/ShaderPass\.js'/,
+			/from\s+'three\/examples\/jsm\/postprocessing\/ShaderPass\.js'/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/from\s+'three\/examples\/jsm\/postprocessing\/OutputPass\.js'/,
+			/from\s+'three\/examples\/jsm\/postprocessing\/OutputPass\.js'/u,
 		)
 	})
 
 	it('imports dither / scanline / upscale shaders from crt-dither', () => {
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/from\s+'\$lib\/game-kit\/crt-dither'/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/from\s+'\$lib\/game-kit\/crt-dither'/u)
 		expect(CRT_DITHER_PASS_SOURCE).toContain('DITHER_FRAGMENT_SHADER')
 		expect(CRT_DITHER_PASS_SOURCE).toContain('DITHER_VERTEX_SHADER')
 		expect(CRT_DITHER_PASS_SOURCE).toContain('SCANLINE_FRAGMENT_SHADER')
@@ -32,21 +32,21 @@ describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 
 	it('uses useThrelte and useTask from @threlte/core', () => {
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/import\s*\{[^}]*useThrelte[^}]*\}\s*from\s*'@threlte\/core'/,
+			/import\s*\{[^}]*useThrelte[^}]*\}\s*from\s*'@threlte\/core'/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/import\s*\{[^}]*useTask[^}]*\}\s*from\s*'@threlte\/core'/,
+			/import\s*\{[^}]*useTask[^}]*\}\s*from\s*'@threlte\/core'/u,
 		)
 	})
 
 	it('disables Threlte default auto-render so the composer drives the frame', () => {
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/ctx\.autoRender\.set\(\s*false\s*\)/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/ctx\.autoRender\.set\(\s*false\s*\)/u)
 	})
 
 	it('renders both composers in a useTask scheduled on ctx.renderStage', () => {
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/useTask\([\s\S]*lo_composer\.render\(/)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/useTask\([\s\S]*hi_composer\.render\(/)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/stage:\s*ctx\.renderStage/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/useTask\([\s\S]*lo_composer\.render\(/u)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/useTask\([\s\S]*hi_composer\.render\(/u)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/stage:\s*ctx\.renderStage/u)
 	})
 
 	it('Stage 1 adds passes in order: RenderPass → OutputPass → ShaderPass(dither)', () => {
@@ -75,21 +75,21 @@ describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 
 	it('syncs lo_composer and hi_composer sizes inside the render task (not $effect)', () => {
 		// Same rAF-vs-microtask rationale as the original single-composer setup.
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*Vector2[^}]*\}\s*from\s*'three'/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*Vector2[^}]*\}\s*from\s*'three'/u)
 		expect(CRT_DITHER_PASS_SOURCE).toContain('lo_composer.setSize(')
 		expect(CRT_DITHER_PASS_SOURCE).toContain('lo_composer.setPixelRatio(lo_dpr)')
 		expect(CRT_DITHER_PASS_SOURCE).toContain('hi_composer.setSize(')
 		expect(CRT_DITHER_PASS_SOURCE).toContain('hi_composer.setPixelRatio(ctx.dpr.current)')
 		expect(CRT_DITHER_PASS_SOURCE).toContain('dither_uniforms.u_resolution.value.set(')
 		// Negative: must NOT compute u_resolution from CSS × DPR (old bug).
-		expect(CRT_DITHER_PASS_SOURCE).not.toMatch(/u_resolution\.value\.set\(\s*width\s*\*\s*dpr/)
+		expect(CRT_DITHER_PASS_SOURCE).not.toMatch(/u_resolution\.value\.set\(\s*width\s*\*\s*dpr/u)
 	})
 
 	it('initializes the u_color_levels uniform as a Vector3 (per-channel quantization)', () => {
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/u_color_levels:\s*\{\s*value:\s*new Vector3\(\s*COLOR_LEVELS\.r,\s*COLOR_LEVELS\.g,\s*COLOR_LEVELS\.b\s*\)\s*\}/,
+			/u_color_levels:\s*\{\s*value:\s*new Vector3\(\s*COLOR_LEVELS\.r,\s*COLOR_LEVELS\.g,\s*COLOR_LEVELS\.b\s*\)\s*\}/u,
 		)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*Vector3[^}]*\}\s*from\s*'three'/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*Vector3[^}]*\}\s*from\s*'three'/u)
 	})
 
 	it('wraps the uniforms in a ShaderMaterial before passing to ShaderPass', () => {
@@ -99,38 +99,40 @@ describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 		// actually reads, leaving u_resolution stuck at (1,1) and the bayer texture sampling
 		// a single cell (no visible dither, dark pixels crushed). Passing a ShaderMaterial
 		// avoids the clone (ShaderPass uses material.uniforms directly).
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*ShaderMaterial[^}]*\}\s*from\s*'three'/)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/new ShaderMaterial\(\s*\{\s*uniforms:\s*dither_uniforms[\s\S]*?\}\s*\)/,
+			/import\s*\{[^}]*ShaderMaterial[^}]*\}\s*from\s*'three'/u,
 		)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/new ShaderPass\(\s*dither_material\s*\)/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(
+			/new ShaderMaterial\(\s*\{\s*uniforms:\s*dither_uniforms[\s\S]*?\}\s*\)/u,
+		)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/new ShaderPass\(\s*dither_material\s*\)/u)
 		// Negative: must NOT pass a plain object literal to ShaderPass (the bug pattern).
-		expect(CRT_DITHER_PASS_SOURCE).not.toMatch(/new ShaderPass\(\s*\{\s*uniforms:/)
+		expect(CRT_DITHER_PASS_SOURCE).not.toMatch(/new ShaderPass\(\s*\{\s*uniforms:/u)
 	})
 
 	it('forces NearestFilter on lo_composer render targets (keeps dither dots crisp)', () => {
 		// NearestFilter prevents bilinear blur when the lo-res dithered output is
 		// sampled by the upscale pass — ensures the pixel art dots stay sharp.
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*NearestFilter[^}]*\}\s*from\s*'three'/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/import\s*\{[^}]*NearestFilter[^}]*\}\s*from\s*'three'/u)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/lo_composer\.renderTarget1\.texture\.minFilter\s*=\s*NearestFilter/,
+			/lo_composer\.renderTarget1\.texture\.minFilter\s*=\s*NearestFilter/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/lo_composer\.renderTarget1\.texture\.magFilter\s*=\s*NearestFilter/,
+			/lo_composer\.renderTarget1\.texture\.magFilter\s*=\s*NearestFilter/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/lo_composer\.renderTarget2\.texture\.minFilter\s*=\s*NearestFilter/,
+			/lo_composer\.renderTarget2\.texture\.minFilter\s*=\s*NearestFilter/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/lo_composer\.renderTarget2\.texture\.magFilter\s*=\s*NearestFilter/,
+			/lo_composer\.renderTarget2\.texture\.magFilter\s*=\s*NearestFilter/u,
 		)
 	})
 
 	it('imports crt store and bypasses the CRT pipeline when CRT is disabled', () => {
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/from\s+'\$lib\/game-kit\/crt\.svelte'/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/from\s+'\$lib\/game-kit\/crt\.svelte'/u)
 		expect(CRT_DITHER_PASS_SOURCE).toContain('crt.is_crt_enabled')
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/ctx\.renderer\.render\(ctx\.scene,\s*ctx\.camera\.current\)/,
+			/ctx\.renderer\.render\(ctx\.scene,\s*ctx\.camera\.current\)/u,
 		)
 	})
 
@@ -138,24 +140,24 @@ describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 		expect(CRT_DITHER_PASS_SOURCE).toContain('SCANLINE_BLEED_FULL_PERIOD')
 		// u_bleed.value must be assigned dynamically (not only at init time)
 		// so that short-period viewports (mobile) get reduced bleed.
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/u_bleed\.value\s*=\s*Math\.min\(/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/u_bleed\.value\s*=\s*Math\.min\(/u)
 	})
 
 	it('rounds u_scanline_period to nearest integer and clamps to minimum valid period', () => {
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/Math\.round\([^)]*DOTS_PER_SCANLINE[^)]*SCANLINE_PHASES_PER_CYCLE[^)]*hi_lo_ratio[^)]*\)/,
+			/Math\.round\([^)]*DOTS_PER_SCANLINE[^)]*SCANLINE_PHASES_PER_CYCLE[^)]*hi_lo_ratio[^)]*\)/u,
 		)
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/Math\.max\(\s*DOTS_PER_SCANLINE\s*\*\s*SCANLINE_PHASES_PER_CYCLE/,
+			/Math\.max\(\s*DOTS_PER_SCANLINE\s*\*\s*SCANLINE_PHASES_PER_CYCLE/u,
 		)
 	})
 
 	it('disposes both composers, bayer texture, and restores autoRender on unmount', () => {
 		expect(CRT_DITHER_PASS_SOURCE).toMatch(
-			/onDestroy\(\s*\(\)\s*=>\s*\{[\s\S]*lo_composer\.dispose\(\)/,
+			/onDestroy\(\s*\(\)\s*=>\s*\{[\s\S]*lo_composer\.dispose\(\)/u,
 		)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/hi_composer\.dispose\(\)/)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/bayer_texture\.dispose\(\)/)
-		expect(CRT_DITHER_PASS_SOURCE).toMatch(/onDestroy\([\s\S]*ctx\.autoRender\.set\(\s*true\s*\)/)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/hi_composer\.dispose\(\)/u)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/bayer_texture\.dispose\(\)/u)
+		expect(CRT_DITHER_PASS_SOURCE).toMatch(/onDestroy\([\s\S]*ctx\.autoRender\.set\(\s*true\s*\)/u)
 	})
 })

--- a/src/lib/game-kit/GameScene.svelte.test.ts
+++ b/src/lib/game-kit/GameScene.svelte.test.ts
@@ -71,13 +71,13 @@ describe('GameScene', () => {
 		// component is wired up with the {#if !is_started} guard so the controls
 		// overlay disappears once the session starts.
 		expect(GAME_SCENE_SOURCE).toMatch(
-			/import\s+ControlsScene\s+from\s+'\$lib\/game-kit\/controls\/ControlsScene\.svelte'/,
+			/import\s+ControlsScene\s+from\s+'\$lib\/game-kit\/controls\/ControlsScene\.svelte'/u,
 		)
-		expect(GAME_SCENE_SOURCE).toMatch(/\{#if\s+!is_started\}[\s\S]*<ControlsScene[\s\S]*\{\/if\}/)
+		expect(GAME_SCENE_SOURCE).toMatch(/\{#if\s+!is_started\}[\s\S]*<ControlsScene[\s\S]*\{\/if\}/u)
 	})
 
 	it('passes hint_text and is_touch into <ControlsScene />', () => {
-		expect(GAME_SCENE_SOURCE).toMatch(/<ControlsScene\s+\{hint_text\}\s+\{is_touch\}\s*\/>/)
+		expect(GAME_SCENE_SOURCE).toMatch(/<ControlsScene\s+\{hint_text\}\s+\{is_touch\}\s*\/>/u)
 	})
 
 	it('calls on_start callback when user first clicks', () => {
@@ -307,7 +307,7 @@ describe('GameScene', () => {
 	describe('dynamic pixel DPR — dot count stays consistent on narrow viewports', () => {
 		it('imports compute_pixel_dpr from the pixel-dpr helper', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/import\s*\{\s*compute_pixel_dpr\s*\}\s*from\s*'\$lib\/game-kit\/pixel-dpr'/,
+				/import\s*\{\s*compute_pixel_dpr\s*\}\s*from\s*'\$lib\/game-kit\/pixel-dpr'/u,
 			)
 		})
 
@@ -330,9 +330,9 @@ describe('GameScene', () => {
 		})
 
 		it('defines shorter-edge-based DPR constants: TARGET_SHORT_EDGE_PIXELS=256 and MIN_SHORT_EDGE_PIXELS=128', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/const\s+TARGET_SHORT_EDGE_PIXELS\s*=\s*256/)
-			expect(GAME_SCENE_SOURCE).toMatch(/const\s+MIN_SHORT_EDGE_PIXELS\s*=\s*128/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/TARGET_LONG_EDGE_PIXELS/)
+			expect(GAME_SCENE_SOURCE).toMatch(/const\s+TARGET_SHORT_EDGE_PIXELS\s*=\s*256/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/const\s+MIN_SHORT_EDGE_PIXELS\s*=\s*128/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/TARGET_LONG_EDGE_PIXELS/u)
 		})
 	})
 
@@ -368,23 +368,23 @@ describe('GameScene', () => {
 		})
 
 		it('.crt-overlay still carries static glass-face cues (vignette + highlight)', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/\.crt-overlay\s*\{/)
-			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*ellipse\s+at\s+center/)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.crt-overlay\s*\{/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*ellipse\s+at\s+center/u)
 		})
 
 		it('GameScene no longer owns DOTS_PER_SCANLINE / device_pixel_ratio / scanline-derived state', () => {
-			expect(GAME_SCENE_SOURCE).not.toMatch(/const\s+DOTS_PER_SCANLINE\s*=/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/let\s+device_pixel_ratio\s*=\s*\$state\(/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_period_css/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_angle_css/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/let\s+is_portrait\s*=\s*\$derived/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/const\s+DOTS_PER_SCANLINE\s*=/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/let\s+device_pixel_ratio\s*=\s*\$state\(/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_period_css/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_angle_css/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/let\s+is_portrait\s*=\s*\$derived/u)
 		})
 
 		it('does not overlay a phosphor mask (RGB sub-pixel stripes) — kept off intentionally', () => {
-			expect(GAME_SCENE_SOURCE).not.toMatch(/repeating-linear-gradient\(\s*90deg/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/rgba\(\s*255,\s*0,\s*0/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/rgba\(\s*0,\s*255,\s*0/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/rgba\(\s*0,\s*0,\s*255/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/repeating-linear-gradient\(\s*90deg/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/rgba\(\s*255,\s*0,\s*0/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/rgba\(\s*0,\s*255,\s*0/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/rgba\(\s*0,\s*0,\s*255/u)
 		})
 
 		it('applies a CRT vibrance filter to the canvas under .crt-active (lowered contrast + boosted saturation, no hue shift)', () => {
@@ -395,10 +395,10 @@ describe('GameScene', () => {
 			// back to prior tunings is caught.
 			// Filter is now gated on .crt-active so toggling CRT off removes all post-processing.
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\.crt-active\s+:global\(canvas\)\s*\{[\s\S]*?filter:\s*contrast\(0\.9\)\s+saturate\(1\.8\)\s+brightness\(1\.1\)\s+url\(#crt-chromatic\)/,
+				/\.game-container\.crt-active\s+:global\(canvas\)\s*\{[\s\S]*?filter:\s*contrast\(0\.9\)\s+saturate\(1\.8\)\s+brightness\(1\.1\)\s+url\(#crt-chromatic\)/u,
 			)
 			expect(GAME_SCENE_SOURCE).not.toMatch(
-				/\.game-container\.crt-active\s+:global\(canvas\)[\s\S]*?hue-rotate/,
+				/\.game-container\.crt-active\s+:global\(canvas\)[\s\S]*?hue-rotate/u,
 			)
 			// Negative: previous filter values must not be present on the canvas filter chain.
 			for (const prior of [
@@ -409,6 +409,7 @@ describe('GameScene', () => {
 				expect(GAME_SCENE_SOURCE).not.toMatch(
 					new RegExp(
 						`\\.game-container\\.crt-active\\s+:global\\(canvas\\)\\s*\\{[\\s\\S]*?filter:[^;]*${prior}`,
+						'u',
 					),
 				)
 			}
@@ -417,8 +418,8 @@ describe('GameScene', () => {
 
 	describe('CRT scanline orientation — driven by the shader, not CSS', () => {
 		it('GameScene no longer owns scanline-orientation logic (moved to CrtDitherPass)', () => {
-			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_angle_css/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/--scanline-angle/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_angle_css/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/--scanline-angle/u)
 			expect(GAME_SCENE_SOURCE).not.toContain('repeating-linear-gradient')
 		})
 	})
@@ -426,19 +427,19 @@ describe('GameScene', () => {
 	describe('CRT curvature — rounded corners + corner darkening + glass-dome highlight', () => {
 		it('applies a border-radius to the canvas to simulate the CRT screen shape', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\s*:global\(canvas\)\s*\{[\s\S]*?border-radius:\s*clamp\(/,
+				/\.game-container\s*:global\(canvas\)\s*\{[\s\S]*?border-radius:\s*clamp\(/u,
 			)
 		})
 
 		it('applies the same border-radius to .crt-overlay so scanlines clip on the same curve', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/\.crt-overlay\s*\{[\s\S]*?border-radius:\s*clamp\(/)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.crt-overlay\s*\{[\s\S]*?border-radius:\s*clamp\(/u)
 		})
 
 		it('adds four corner darkening radial-gradients to fake CRT curvature', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+top\s+left/)
-			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+top\s+right/)
-			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+bottom\s+left/)
-			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+bottom\s+right/)
+			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+top\s+left/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+top\s+right/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+bottom\s+left/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/radial-gradient\(\s*circle\s+at\s+bottom\s+right/u)
 		})
 
 		it('uses alpha 0.4 for the four corner darkening gradients (lightened from 0.55 for legibility)', () => {
@@ -451,24 +452,25 @@ describe('GameScene', () => {
 				expect(GAME_SCENE_SOURCE).toMatch(
 					new RegExp(
 						`radial-gradient\\(\\s*circle\\s+at\\s+${corner},\\s*rgba\\(\\s*0,\\s*0,\\s*0,\\s*0\\.4\\s*\\)`,
+						'u',
 					),
 				)
 			}
 			// Negative: the prior 0.55 alpha must not be present in any corner-darkening position.
 			expect(GAME_SCENE_SOURCE).not.toMatch(
-				/radial-gradient\(\s*circle\s+at\s+(?:top|bottom)\s+(?:left|right),\s*rgba\(\s*0,\s*0,\s*0,\s*0\.55\s*\)/,
+				/radial-gradient\(\s*circle\s+at\s+(?:top|bottom)\s+(?:left|right),\s*rgba\(\s*0,\s*0,\s*0,\s*0\.55\s*\)/u,
 			)
 		})
 
 		it('adds a glass-dome highlight (light radial gradient in the upper-left quadrant)', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/radial-gradient\(\s*ellipse\s+\d+%\s+\d+%\s+at\s+\d+%\s+\d+%,[\s\S]*?rgba\(\s*255,\s*255,\s*255/,
+				/radial-gradient\(\s*ellipse\s+\d+%\s+\d+%\s+at\s+\d+%\s+\d+%,[\s\S]*?rgba\(\s*255,\s*255,\s*255/u,
 			)
 		})
 
 		it('keeps the center vignette alongside the curvature layers (scanlines now in shader)', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/radial-gradient\(\s*ellipse\s+at\s+center,\s*transparent\s+50%/,
+				/radial-gradient\(\s*ellipse\s+at\s+center,\s*transparent\s+50%/u,
 			)
 			expect(GAME_SCENE_SOURCE).not.toContain('repeating-linear-gradient')
 		})
@@ -479,11 +481,11 @@ describe('GameScene', () => {
 			// 0.3 to lift the screen-edge brightness. Pinning the value catches drift in
 			// either direction.
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/radial-gradient\(\s*ellipse\s+at\s+center,\s*transparent\s+50%,\s*rgba\(\s*0,\s*0,\s*0,\s*0\.3\s*\)\s+100%\s*\)/,
+				/radial-gradient\(\s*ellipse\s+at\s+center,\s*transparent\s+50%,\s*rgba\(\s*0,\s*0,\s*0,\s*0\.3\s*\)\s+100%\s*\)/u,
 			)
 			// Negative: prior 0.45 alpha must not be at the vignette's outer stop.
 			expect(GAME_SCENE_SOURCE).not.toMatch(
-				/radial-gradient\(\s*ellipse\s+at\s+center,\s*transparent\s+50%,\s*rgba\(\s*0,\s*0,\s*0,\s*0\.45\s*\)/,
+				/radial-gradient\(\s*ellipse\s+at\s+center,\s*transparent\s+50%,\s*rgba\(\s*0,\s*0,\s*0,\s*0\.45\s*\)/u,
 			)
 		})
 	})
@@ -491,26 +493,26 @@ describe('GameScene', () => {
 	describe('CRT color quantization + Bayer dithering (WebGL post-process)', () => {
 		it('imports CrtDitherPass and renders it inside <Canvas>', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/import\s+CrtDitherPass\s+from\s+'\$lib\/game-kit\/CrtDitherPass\.svelte'/,
+				/import\s+CrtDitherPass\s+from\s+'\$lib\/game-kit\/CrtDitherPass\.svelte'/u,
 			)
-			expect(GAME_SCENE_SOURCE).toMatch(/<Canvas[\s\S]*<CrtDitherPass[^/]*\/>[\s\S]*<\/Canvas>/)
+			expect(GAME_SCENE_SOURCE).toMatch(/<Canvas[\s\S]*<CrtDitherPass[^/]*\/>[\s\S]*<\/Canvas>/u)
 		})
 
 		it('no longer references the legacy SVG palette filter (replaced by GPU post-process)', () => {
-			expect(GAME_SCENE_SOURCE).not.toMatch(/<filter\s+id="crt-palette"/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/feComponentTransfer/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/url\(#crt-palette\)/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/\.crt-filter-defs\s*\{/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/<filter\s+id="crt-palette"/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/feComponentTransfer/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/url\(#crt-palette\)/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/\.crt-filter-defs\s*\{/u)
 		})
 	})
 
 	describe('CRT chromatic aberration — wiring into GameScene', () => {
 		it('imports <CrtChromaticFilter /> and renders it conditionally when CRT is enabled', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/import\s+CrtChromaticFilter\s+from\s+'\$lib\/game-kit\/CrtChromaticFilter\.svelte'/,
+				/import\s+CrtChromaticFilter\s+from\s+'\$lib\/game-kit\/CrtChromaticFilter\.svelte'/u,
 			)
-			expect(GAME_SCENE_SOURCE).toMatch(/<CrtChromaticFilter\s*\/>/)
-			expect(GAME_SCENE_SOURCE).toMatch(/\{#if\s+is_crt_enabled\}[\s\S]*<CrtChromaticFilter/)
+			expect(GAME_SCENE_SOURCE).toMatch(/<CrtChromaticFilter\s*\/>/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/\{#if\s+is_crt_enabled\}[\s\S]*<CrtChromaticFilter/u)
 		})
 
 		it('applies the chromatic filter to the canvas via CSS filter chain under .crt-active', () => {
@@ -519,7 +521,7 @@ describe('GameScene', () => {
 			// connects GameScene's <canvas> to the externally-defined filter.
 			// Filter is now gated on .crt-active so toggling CRT off removes all post-processing.
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\.crt-active\s*:global\(canvas\)\s*\{[\s\S]*?filter:[^;]*url\(#crt-chromatic\)/,
+				/\.game-container\.crt-active\s*:global\(canvas\)\s*\{[\s\S]*?filter:[^;]*url\(#crt-chromatic\)/u,
 			)
 		})
 
@@ -534,12 +536,12 @@ describe('GameScene', () => {
 	describe('safe-area drawing when fullscreen is engaged (Issue #80)', () => {
 		it('derives is_fullscreen_active from fullscreen.is_active', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/let\s+is_fullscreen_active\s*=\s*\$derived\(\s*fullscreen\.is_active\s*\)/,
+				/let\s+is_fullscreen_active\s*=\s*\$derived\(\s*fullscreen\.is_active\s*\)/u,
 			)
 		})
 
 		it('binds class:is-fullscreen on the game-container using is_fullscreen_active', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/class:is-fullscreen=\{is_fullscreen_active\}/)
+			expect(GAME_SCENE_SOURCE).toMatch(/class:is-fullscreen=\{is_fullscreen_active\}/u)
 		})
 
 		it('applies the is-fullscreen class when fullscreen.is_active is true', () => {
@@ -560,33 +562,33 @@ describe('GameScene', () => {
 
 		it('default .game-container reserves safe-area-inset padding on all four sides', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\s*\{[\s\S]*?padding-top:\s*env\(safe-area-inset-top/,
+				/\.game-container\s*\{[\s\S]*?padding-top:\s*env\(safe-area-inset-top/u,
 			)
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\s*\{[\s\S]*?padding-right:\s*env\(safe-area-inset-right/,
+				/\.game-container\s*\{[\s\S]*?padding-right:\s*env\(safe-area-inset-right/u,
 			)
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\s*\{[\s\S]*?padding-bottom:\s*env\(safe-area-inset-bottom/,
+				/\.game-container\s*\{[\s\S]*?padding-bottom:\s*env\(safe-area-inset-bottom/u,
 			)
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.game-container\s*\{[\s\S]*?padding-left:\s*env\(safe-area-inset-left/,
+				/\.game-container\s*\{[\s\S]*?padding-left:\s*env\(safe-area-inset-left/u,
 			)
 		})
 
 		it('.game-container uses box-sizing: border-box so the safe-area padding does not bloat the box', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/\.game-container\s*\{[\s\S]*?box-sizing:\s*border-box/)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.game-container\s*\{[\s\S]*?box-sizing:\s*border-box/u)
 		})
 
 		it('.game-container.is-fullscreen drops the safe-area padding so content extends edge-to-edge', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/\.game-container\.is-fullscreen\s*\{[\s\S]*?padding:\s*0/)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.game-container\.is-fullscreen\s*\{[\s\S]*?padding:\s*0/u)
 		})
 
 		it('.pause-btn offset includes env(safe-area-inset-*) so the button stays clear of OS UI even in fullscreen', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.pause-btn\s*\{[\s\S]*?bottom:\s*calc\([^)]*env\(safe-area-inset-bottom/,
+				/\.pause-btn\s*\{[\s\S]*?bottom:\s*calc\([^)]*env\(safe-area-inset-bottom/u,
 			)
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.pause-btn\s*\{[\s\S]*?right:\s*calc\([^)]*env\(safe-area-inset-right/,
+				/\.pause-btn\s*\{[\s\S]*?right:\s*calc\([^)]*env\(safe-area-inset-right/u,
 			)
 		})
 	})
@@ -594,7 +596,7 @@ describe('GameScene', () => {
 	describe('antialiasing — enabled on desktop when RETRO mode is off (Issue #116)', () => {
 		it('imports should_use_antialias from the antialias helper', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/import\s*\{\s*should_use_antialias\s*\}\s*from\s*'\$lib\/game-kit\/antialias'/,
+				/import\s*\{\s*should_use_antialias\s*\}\s*from\s*'\$lib\/game-kit\/antialias'/u,
 			)
 		})
 
@@ -604,7 +606,7 @@ describe('GameScene', () => {
 			// Always-on AA on desktop is masked by the CRT post-process when RETRO is on, so we
 			// only need is_touch as the input.
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/let\s+is_aa_enabled\s*=\s*\$derived\(\s*should_use_antialias\(\s*is_touch\s*\)\s*\)/,
+				/let\s+is_aa_enabled\s*=\s*\$derived\(\s*should_use_antialias\(\s*is_touch\s*\)\s*\)/u,
 			)
 		})
 
@@ -612,20 +614,20 @@ describe('GameScene', () => {
 			// Negative pin: a `{#key is_aa_enabled}` or `{#key is_crt_enabled}` wrapper would
 			// destroy and recreate the WebGL context on toggle, resetting player position and
 			// scene state. Keep the Canvas mounted for the lifetime of the GameScene.
-			expect(GAME_SCENE_SOURCE).not.toMatch(/\{#key\s+is_aa_enabled\}/)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/\{#key\s+is_crt_enabled\}/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/\{#key\s+is_aa_enabled\}/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/\{#key\s+is_crt_enabled\}/u)
 		})
 
 		it('passes the antialias flag into the renderer factory via createRenderer', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/createRenderer=\{\s*create_renderer_factory\(\s*is_aa_enabled\s*\)\s*\}/,
+				/createRenderer=\{\s*create_renderer_factory\(\s*is_aa_enabled\s*\)\s*\}/u,
 			)
 		})
 
 		it('no longer hardcodes antialias: false on the WebGLRenderer call', () => {
 			// Negative pin: a future regression that re-introduces the hardcoded `antialias: false`
 			// literal would silently break the desktop-RETRO-off path.
-			expect(GAME_SCENE_SOURCE).not.toMatch(/antialias:\s*false/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/antialias:\s*false/u)
 		})
 	})
 
@@ -660,22 +662,22 @@ describe('GameScene', () => {
 			// component without an explicit `@source "../../node_modules/.../dist/**/*.svelte"`
 			// would not generate the `sr-only` utility, and the live-region would fall back to
 			// display: block and render as a ~24px visible band at the top of the viewport.
-			expect(GAME_SCENE_SOURCE).not.toMatch(/class="sr-only"/)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/class="sr-only"/u)
 		})
 
 		it('defines a scoped .visually-hidden style using the standard hiding scaffolding', () => {
 			// Standard visually-hidden pattern: 1px box, overflow hidden, clip rect, no white-space wrap.
-			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?position:\s*absolute/)
-			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?width:\s*1px/)
-			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?height:\s*1px/)
-			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?overflow:\s*hidden/)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?position:\s*absolute/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?width:\s*1px/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?height:\s*1px/u)
+			expect(GAME_SCENE_SOURCE).toMatch(/\.visually-hidden\s*\{[\s\S]*?overflow:\s*hidden/u)
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/\.visually-hidden\s*\{[\s\S]*?clip:\s*rect\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\)/,
+				/\.visually-hidden\s*\{[\s\S]*?clip:\s*rect\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\)/u,
 			)
 		})
 
 		it('applies the scoped visually-hidden class to the [role="status"] element', () => {
-			expect(GAME_SCENE_SOURCE).toMatch(/<div\s+role="status"\s+class="visually-hidden">/)
+			expect(GAME_SCENE_SOURCE).toMatch(/<div\s+role="status"\s+class="visually-hidden">/u)
 		})
 	})
 })

--- a/src/lib/game-kit/app-html.test.ts
+++ b/src/lib/game-kit/app-html.test.ts
@@ -6,17 +6,17 @@ const APP_HTML = readFileSync('src/app.html', 'utf-8')
 describe('app.html — mobile safe-area / PWA fullscreen meta tags', () => {
 	it('viewport meta declares viewport-fit=cover so env(safe-area-inset-*) becomes non-zero on iOS', () => {
 		expect(APP_HTML).toMatch(
-			/<meta\s+name="viewport"\s+content="[^"]*viewport-fit=cover[^"]*"\s*\/?>/,
+			/<meta\s+name="viewport"\s+content="[^"]*viewport-fit=cover[^"]*"\s*\/?>/u,
 		)
 	})
 
 	it('declares apple-mobile-web-app-capable="yes" so the iOS PWA launches without browser chrome', () => {
-		expect(APP_HTML).toMatch(/<meta\s+name="apple-mobile-web-app-capable"\s+content="yes"\s*\/?>/)
+		expect(APP_HTML).toMatch(/<meta\s+name="apple-mobile-web-app-capable"\s+content="yes"\s*\/?>/u)
 	})
 
 	it('declares apple-mobile-web-app-status-bar-style="black-translucent" so iOS PWA content draws under the status bar', () => {
 		expect(APP_HTML).toMatch(
-			/<meta\s+name="apple-mobile-web-app-status-bar-style"\s+content="black-translucent"\s*\/?>/,
+			/<meta\s+name="apple-mobile-web-app-status-bar-style"\s+content="black-translucent"\s*\/?>/u,
 		)
 	})
 })

--- a/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
+++ b/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
@@ -99,7 +99,7 @@ describe('ControlsScene dual-backdrop — icons dim through backdrop from both s
 		// Reason: the other tests only check that opacity={BACKDROP_OPACITY} is wired up,
 		// so silent value drift wouldn't be caught. Pin the literal value here so visual
 		// regressions on the CLICK TO START backdrop are surfaced.
-		expect(SOURCE).toMatch(/const\s+BACKDROP_OPACITY\s*=\s*0\.9/)
+		expect(SOURCE).toMatch(/const\s+BACKDROP_OPACITY\s*=\s*0\.9/u)
 	})
 
 	it('icon materials are DoubleSide so they remain visible when viewed from behind', () => {
@@ -124,19 +124,19 @@ describe('ControlsScene dual-backdrop — icons dim through backdrop from both s
 	})
 
 	it('FrontSide, BackSide, and DoubleSide are all imported from three', () => {
-		expect(SOURCE).toMatch(/import\s*\{[^}]*\bFrontSide\b[^}]*\}\s*from\s*'three'/)
-		expect(SOURCE).toMatch(/import\s*\{[^}]*\bBackSide\b[^}]*\}\s*from\s*'three'/)
-		expect(SOURCE).toMatch(/import\s*\{[^}]*\bDoubleSide\b[^}]*\}\s*from\s*'three'/)
+		expect(SOURCE).toMatch(/import\s*\{[^}]*\bFrontSide\b[^}]*\}\s*from\s*'three'/u)
+		expect(SOURCE).toMatch(/import\s*\{[^}]*\bBackSide\b[^}]*\}\s*from\s*'three'/u)
+		expect(SOURCE).toMatch(/import\s*\{[^}]*\bDoubleSide\b[^}]*\}\s*from\s*'three'/u)
 	})
 })
 
 describe('ControlsScene PC icon fit — keyboard and mouse must not overflow the viewport', () => {
 	it('keyboard and mouse meshes are wrapped in a T.Group with scale={pc_scale}', () => {
-		expect(SOURCE).toMatch(/<T\.Group[^>]*\bscale=\{pc_scale\}/)
+		expect(SOURCE).toMatch(/<T\.Group[^>]*\bscale=\{pc_scale\}/u)
 	})
 
 	it('PC group is positioned at the shared y/z so scaling keeps icons vertically anchored', () => {
-		expect(SOURCE).toMatch(/<T\.Group\s+position=\{\[0,\s*PC_GROUP_Y,\s*PC_GROUP_Z\]\}/)
+		expect(SOURCE).toMatch(/<T\.Group\s+position=\{\[0,\s*PC_GROUP_Y,\s*PC_GROUP_Z\]\}/u)
 	})
 
 	it('keyboard mesh uses group-local position [KEYBOARD_X, 0, 0]', () => {
@@ -155,26 +155,26 @@ describe('ControlsScene PC icon fit — keyboard and mouse must not overflow the
 
 	it('compute_fit_scale is imported from the controls-fit helper module', () => {
 		expect(SOURCE).toMatch(
-			/import\s*\{\s*compute_fit_scale\s*\}\s*from\s*'\$lib\/game-kit\/controls\/controls-fit'/,
+			/import\s*\{\s*compute_fit_scale\s*\}\s*from\s*'\$lib\/game-kit\/controls\/controls-fit'/u,
 		)
 	})
 
 	it('PC_NATURAL_SPAN and PC_MIN_SIDE_PADDING constants are defined (min padding constraint replaces width ratio)', () => {
-		expect(SOURCE).toMatch(/const\s+PC_NATURAL_SPAN\s*=/)
-		expect(SOURCE).toMatch(/const\s+PC_MIN_SIDE_PADDING\s*=\s*0\.138/)
-		expect(SOURCE).not.toMatch(/PC_SAFE_WIDTH_RATIO/)
+		expect(SOURCE).toMatch(/const\s+PC_NATURAL_SPAN\s*=/u)
+		expect(SOURCE).toMatch(/const\s+PC_MIN_SIDE_PADDING\s*=\s*0\.138/u)
+		expect(SOURCE).not.toMatch(/PC_SAFE_WIDTH_RATIO/u)
 	})
 
 	it('hint text group is scaled by pc_scale so it shrinks together with the icons (does not overflow icon span)', () => {
 		expect(SOURCE).toMatch(
-			/<T\.Group\s+position=\{\[HINT_X,\s*HINT_Y,\s*HINT_Z\]\}\s+scale=\{pc_scale\}/,
+			/<T\.Group\s+position=\{\[HINT_X,\s*HINT_Y,\s*HINT_Z\]\}\s+scale=\{pc_scale\}/u,
 		)
 	})
 })
 
 describe('ControlsScene keyboard letters — overlaid as Threlte Text using the theme font', () => {
 	it('keyboard SVG contains only key boxes (no <text> elements) — letters are overlaid as Threlte Text', () => {
-		const svg_match = SOURCE.match(/const\s+KEYBOARD_SVG\s*=\s*`([\s\S]*?)`/)
+		const svg_match = SOURCE.match(/const\s+KEYBOARD_SVG\s*=\s*`([\s\S]*?)`/u)
 		expect(svg_match).not.toBeNull()
 		const svg_body = svg_match?.[1] ?? ''
 		expect(svg_body).not.toContain('<text')
@@ -183,8 +183,8 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 	})
 
 	it('KEYBOARD_LETTERS array enumerates all 7 letter overlays (W, A, S, D, ESC, /, Z)', () => {
-		expect(SOURCE).toMatch(/const\s+KEYBOARD_LETTERS\s*:\s*ReadonlyArray<KeyboardLetter>\s*=/)
-		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/)
+		expect(SOURCE).toMatch(/const\s+KEYBOARD_LETTERS\s*:\s*ReadonlyArray<KeyboardLetter>\s*=/u)
+		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		expect(letter_match).not.toBeNull()
 		const block = letter_match?.[0] ?? ''
 		expect(block).toContain("text: 'W'")
@@ -199,48 +199,48 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 	it('WASD letters are pinned to vsize 16 — kept large for readability', () => {
 		// Reason: vsize is the only signal of intentional visual sizing; without pinning,
 		// silent drift during unrelated edits could shrink the keys back.
-		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/)
+		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		const block = letter_match?.[0] ?? ''
-		expect(block).toMatch(/text:\s*'W'[^}]*vsize:\s*16/)
-		expect(block).toMatch(/text:\s*'A'[^}]*vsize:\s*16/)
-		expect(block).toMatch(/text:\s*'S'[^}]*vsize:\s*16/)
-		expect(block).toMatch(/text:\s*'D'[^}]*vsize:\s*16/)
+		expect(block).toMatch(/text:\s*'W'[^}]*vsize:\s*16/u)
+		expect(block).toMatch(/text:\s*'A'[^}]*vsize:\s*16/u)
+		expect(block).toMatch(/text:\s*'S'[^}]*vsize:\s*16/u)
+		expect(block).toMatch(/text:\s*'D'[^}]*vsize:\s*16/u)
 	})
 
 	it('WASD letter vy values are pinned to the lowered key positions (W=38, A/S/D=82)', () => {
 		// Reason: the WASD rows were moved down so the ASD-to-space gap matches the
 		// space-to-ESC gap. The letter vy values must follow the rect centers.
-		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/)
+		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		const block = letter_match?.[0] ?? ''
-		expect(block).toMatch(/text:\s*'W'[^}]*vy:\s*38/)
-		expect(block).toMatch(/text:\s*'A'[^}]*vy:\s*82/)
-		expect(block).toMatch(/text:\s*'S'[^}]*vy:\s*82/)
-		expect(block).toMatch(/text:\s*'D'[^}]*vy:\s*82/)
+		expect(block).toMatch(/text:\s*'W'[^}]*vy:\s*38/u)
+		expect(block).toMatch(/text:\s*'A'[^}]*vy:\s*82/u)
+		expect(block).toMatch(/text:\s*'S'[^}]*vy:\s*82/u)
+		expect(block).toMatch(/text:\s*'D'[^}]*vy:\s*82/u)
 	})
 
 	it('ESC label is pinned to vsize 12 — bumped above 9 to match WASD legibility while staying within its key', () => {
 		// Reason: ESC has 3 glyphs versus the single-glyph WASD/Z keys, so it is sized
 		// smaller than 16 to avoid horizontal overflow within the key rect. Pinning the
 		// literal value prevents accidental regression to the previous tiny size.
-		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/)
+		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		const block = letter_match?.[0] ?? ''
-		expect(block).toMatch(/text:\s*'ESC'[^}]*vsize:\s*12/)
+		expect(block).toMatch(/text:\s*'ESC'[^}]*vsize:\s*12/u)
 	})
 
 	it('provides viewbox → plane coordinate helpers', () => {
-		expect(SOURCE).toMatch(/function\s+viewbox_x_to_plane\s*\(\s*vx\s*:\s*number\s*\)/)
-		expect(SOURCE).toMatch(/function\s+viewbox_y_to_plane\s*\(\s*vy\s*:\s*number\s*\)/)
+		expect(SOURCE).toMatch(/function\s+viewbox_x_to_plane\s*\(\s*vx\s*:\s*number\s*\)/u)
+		expect(SOURCE).toMatch(/function\s+viewbox_y_to_plane\s*\(\s*vy\s*:\s*number\s*\)/u)
 		expect(SOURCE).toMatch(
-			/function\s+viewbox_size_to_world\s*\(\s*vsize\s*:\s*number\s*,\s*size_mul\s*:\s*number\s*\)/,
+			/function\s+viewbox_size_to_world\s*\(\s*vsize\s*:\s*number\s*,\s*size_mul\s*:\s*number\s*\)/u,
 		)
 	})
 
 	it('renders one Threlte Text per letter via {#each KEYBOARD_LETTERS} inside the PC group', () => {
-		expect(SOURCE).toMatch(/\{#each\s+KEYBOARD_LETTERS\s+as\s+letter/)
+		expect(SOURCE).toMatch(/\{#each\s+KEYBOARD_LETTERS\s+as\s+letter/u)
 	})
 
 	it('letter Text uses font={current_font} so it matches the hint text font exactly', () => {
-		const each_block = SOURCE.match(/\{#each\s+KEYBOARD_LETTERS[\s\S]*?\{\/each\}/)
+		const each_block = SOURCE.match(/\{#each\s+KEYBOARD_LETTERS[\s\S]*?\{\/each\}/u)
 		expect(each_block).not.toBeNull()
 		const block = each_block?.[0] ?? ''
 		expect(block).toContain('font={current_font}')
@@ -253,63 +253,65 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 
 	it('uses theme font-size multiplier for visual size parity between PressStart2P and Orbitron', () => {
 		expect(SOURCE).toMatch(
-			/current_font_size_mul\s*=\s*\$derived\(fonts\.get_font_size_multiplier\(should_use_alt_font\)\)/,
+			/current_font_size_mul\s*=\s*\$derived\(fonts\.get_font_size_multiplier\(should_use_alt_font\)\)/u,
 		)
 	})
 
 	it('derives should_use_alt_font from !crt.is_crt_enabled — font swaps with CRT, not CYBER', () => {
 		expect(SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/,
+			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
-		expect(SOURCE).toMatch(/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/)
-		expect(SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
+		expect(SOURCE).toMatch(
+			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/u,
+		)
+		expect(SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/u)
 	})
 
 	it('does not regenerate the keyboard texture on font change (texture is static; only Text overlays react)', () => {
-		expect(SOURCE).not.toMatch(/function\s+make_keyboard_svg\s*\(/)
-		expect(SOURCE).not.toMatch(/old_tex\?\.dispose\(\)/)
+		expect(SOURCE).not.toMatch(/function\s+make_keyboard_svg\s*\(/u)
+		expect(SOURCE).not.toMatch(/old_tex\?\.dispose\(\)/u)
 	})
 })
 
 describe('ControlsScene viewport reactivity — sizes update on window resize', () => {
 	it('subscribes to Threlte size store via $size so $derived reacts to resize', () => {
-		expect(SOURCE).toMatch(/const\s*\{\s*size\s*\}\s*=\s*useThrelte\(\)/)
+		expect(SOURCE).toMatch(/const\s*\{\s*size\s*\}\s*=\s*useThrelte\(\)/u)
 		expect(SOURCE).toContain('$size.width')
 		expect(SOURCE).toContain('$size.height')
 	})
 
 	it('does not use the non-reactive .current accessor on size (would freeze viewport_aspect)', () => {
-		expect(SOURCE).not.toMatch(/\bctx\.size\.current\b/)
-		expect(SOURCE).not.toMatch(/\bsize\.current\.(width|height)\b/)
+		expect(SOURCE).not.toMatch(/\bctx\.size\.current\b/u)
+		expect(SOURCE).not.toMatch(/\bsize\.current\.(width|height)\b/u)
 	})
 })
 
 describe('ControlsScene texture loading — leak-safe blob URLs and unhandled rejections', () => {
 	it('svg_to_texture revokes the object URL in a finally block (no leak on failure)', () => {
-		const fn_match = SOURCE.match(/async\s+function\s+svg_to_texture\([\s\S]*?\n\t\}/)
+		const fn_match = SOURCE.match(/async\s+function\s+svg_to_texture\([\s\S]*?\n\t\}/u)
 		expect(fn_match).not.toBeNull()
 		const body = fn_match?.[0] ?? ''
-		expect(body).toMatch(/\}\s*finally\s*\{[\s\S]*URL\.revokeObjectURL\(url\)[\s\S]*\}/)
+		expect(body).toMatch(/\}\s*finally\s*\{[\s\S]*URL\.revokeObjectURL\(url\)[\s\S]*\}/u)
 	})
 
 	it('svg_to_texture does not call URL.revokeObjectURL outside the finally block', () => {
-		const fn_match = SOURCE.match(/async\s+function\s+svg_to_texture\([\s\S]*?\n\t\}/)
+		const fn_match = SOURCE.match(/async\s+function\s+svg_to_texture\([\s\S]*?\n\t\}/u)
 		const body = fn_match?.[0] ?? ''
-		const revoke_count = (body.match(/URL\.revokeObjectURL\(/g) ?? []).length
+		const revoke_count = (body.match(/URL\.revokeObjectURL\(/gu) ?? []).length
 		expect(revoke_count).toBe(1)
 	})
 
 	it('load_textures catches Promise.all rejection to avoid unhandled rejection', () => {
-		const fn_match = SOURCE.match(/async\s+function\s+load_textures\([\s\S]*?\}\)\(\)/)
+		const fn_match = SOURCE.match(/async\s+function\s+load_textures\([\s\S]*?\}\)\(\)/u)
 		expect(fn_match).not.toBeNull()
 		const body = fn_match?.[0] ?? ''
-		expect(body).toMatch(/try\s*\{[\s\S]*await Promise\.all/)
-		expect(body).toMatch(/\}\s*catch\s*\([^)]*\)\s*\{/)
+		expect(body).toMatch(/try\s*\{[\s\S]*await Promise\.all/u)
+		expect(body).toMatch(/\}\s*catch\s*\([^)]*\)\s*\{/u)
 	})
 })
 
 function extract_const_number(source: string, name: string): number {
-	const re = new RegExp(`const\\s+${name}\\s*=\\s*(-?\\d+(?:\\.\\d+)?)`)
+	const re = new RegExp(`const\\s+${name}\\s*=\\s*(-?\\d+(?:\\.\\d+)?)`, 'u')
 	const match = source.match(re)
 	if (!match) throw new Error(`constant ${name} not found in source`)
 	return Number(match[1])
@@ -426,7 +428,7 @@ const MOUSE_Z_ALIGNMENT_TOLERANCE = 0.01
 
 describe('ControlsScene mouse vertical alignment — mouse body bottom matches Z key bottom', () => {
 	it('MOUSE_Y constant is defined and the mesh uses [MOUSE_X, MOUSE_Y, 0]', () => {
-		expect(SOURCE).toMatch(/const\s+MOUSE_Y\s*=\s*-?\d+(?:\.\d+)?/)
+		expect(SOURCE).toMatch(/const\s+MOUSE_Y\s*=\s*-?\d+(?:\.\d+)?/u)
 		expect(SOURCE).toContain('position={[MOUSE_X, MOUSE_Y, 0]}')
 	})
 
@@ -464,10 +466,10 @@ const TOUCH_SVG_GESTURE_GROUP_COUNT = 2
 
 describe('ControlsScene touch SVG gesture centering — illustration vertically centered within frame', () => {
 	it('both gesture group y-translations center the bounding box within the frame rect', () => {
-		const svg_match = SOURCE.match(/const\s+TOUCH_SVG\s*=\s*`([\s\S]*?)`/)
+		const svg_match = SOURCE.match(/const\s+TOUCH_SVG\s*=\s*`([\s\S]*?)`/u)
 		expect(svg_match).not.toBeNull()
 		const svg_body = svg_match?.[1] ?? ''
-		const translate_matches = [...svg_body.matchAll(/transform="translate\(\d+,(-?\d+)\)"/g)]
+		const translate_matches = [...svg_body.matchAll(/transform="translate\(\d+,(-?\d+)\)"/gu)]
 		expect(translate_matches).toHaveLength(TOUCH_SVG_GESTURE_GROUP_COUNT)
 		for (const match of translate_matches) {
 			const translate_y = Number(match[1])

--- a/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
@@ -52,7 +52,7 @@ describe('KeyboardDiagram', () => {
 		const polylines = Array.from(container.querySelectorAll('.key-space polyline'))
 		expect(polylines).toHaveLength(2)
 		for (const p of polylines) {
-			const points = p.getAttribute('points')?.trim().split(/\s+/) ?? []
+			const points = p.getAttribute('points')?.trim().split(/\s+/u) ?? []
 			expect(points).toHaveLength(3)
 		}
 	})
@@ -65,7 +65,7 @@ describe('KeyboardDiagram', () => {
 				p
 					.getAttribute('points')
 					?.trim()
-					.split(/\s+/)
+					.split(/\s+/u)
 					.map((pt) => Number(pt.split(',')[1])) ?? [],
 		)
 		const span = Math.max(...all_y_values) - Math.min(...all_y_values)

--- a/src/lib/game-kit/crt-barrel.test.ts
+++ b/src/lib/game-kit/crt-barrel.test.ts
@@ -131,8 +131,8 @@ describe('crt_barrel.apply_barrel_uv', () => {
 
 describe('BARREL shader sources', () => {
 	it('vertex shader exposes v_uv and computes gl_Position', () => {
-		expect(BARREL_VERTEX_SHADER).toMatch(/varying\s+vec2\s+v_uv/)
-		expect(BARREL_VERTEX_SHADER).toMatch(/gl_Position\s*=/)
+		expect(BARREL_VERTEX_SHADER).toMatch(/varying\s+vec2\s+v_uv/u)
+		expect(BARREL_VERTEX_SHADER).toMatch(/gl_Position\s*=/u)
 	})
 
 	it('fragment shader declares every required uniform', () => {
@@ -149,8 +149,8 @@ describe('BARREL shader sources', () => {
 	})
 
 	it('fragment shader applies aspect correction (centered.x *= u_aspect ... centered.x /= u_aspect)', () => {
-		expect(BARREL_FRAGMENT_SHADER).toMatch(/centered\.x\s*\*=\s*u_aspect/)
-		expect(BARREL_FRAGMENT_SHADER).toMatch(/centered\.x\s*\/=\s*u_aspect/)
+		expect(BARREL_FRAGMENT_SHADER).toMatch(/centered\.x\s*\*=\s*u_aspect/u)
+		expect(BARREL_FRAGMENT_SHADER).toMatch(/centered\.x\s*\/=\s*u_aspect/u)
 	})
 
 	it('fragment shader masks out-of-bounds samples to black (visible-mask multiply, branchless)', () => {
@@ -158,10 +158,10 @@ describe('BARREL shader sources', () => {
 		// background — the visible mask multiplies those texels by 0 so the frame stays clean.
 		expect(BARREL_FRAGMENT_SHADER).toContain('step(vec2(0.0), sample_uv)')
 		expect(BARREL_FRAGMENT_SHADER).toContain('step(sample_uv, vec2(1.0))')
-		expect(BARREL_FRAGMENT_SHADER).toMatch(/sampled\s*\*\s*visible/)
+		expect(BARREL_FRAGMENT_SHADER).toMatch(/sampled\s*\*\s*visible/u)
 	})
 
 	it('fragment shader applies a quadratic warp (1.0 + u_strength * r2)', () => {
-		expect(BARREL_FRAGMENT_SHADER).toMatch(/1\.0\s*\+\s*u_strength\s*\*\s*r2/)
+		expect(BARREL_FRAGMENT_SHADER).toMatch(/1\.0\s*\+\s*u_strength\s*\*\s*r2/u)
 	})
 })

--- a/src/lib/game-kit/crt-dither.test.ts
+++ b/src/lib/game-kit/crt-dither.test.ts
@@ -278,8 +278,8 @@ describe('crt_dither.create_bayer_texture', () => {
 
 describe('DITHER shader sources', () => {
 	it('vertex shader exposes v_uv and computes gl_Position', () => {
-		expect(DITHER_VERTEX_SHADER).toMatch(/varying\s+vec2\s+v_uv/)
-		expect(DITHER_VERTEX_SHADER).toMatch(/gl_Position\s*=/)
+		expect(DITHER_VERTEX_SHADER).toMatch(/varying\s+vec2\s+v_uv/u)
+		expect(DITHER_VERTEX_SHADER).toMatch(/gl_Position\s*=/u)
 	})
 
 	it('fragment shader declares every required uniform', () => {
@@ -313,11 +313,11 @@ describe('DITHER shader sources', () => {
 	})
 
 	it('fragment shader enforces the black floor with max(..., u_black_floor)', () => {
-		expect(DITHER_FRAGMENT_SHADER).toMatch(/max\(\s*quantized\s*,\s*vec3\(u_black_floor\)\s*\)/)
+		expect(DITHER_FRAGMENT_SHADER).toMatch(/max\(\s*quantized\s*,\s*vec3\(u_black_floor\)\s*\)/u)
 	})
 
 	it('fragment shader declares u_color_levels as vec3 (per-channel quantization)', () => {
-		expect(DITHER_FRAGMENT_SHADER).toMatch(/uniform\s+vec3\s+u_color_levels/)
+		expect(DITHER_FRAGMENT_SHADER).toMatch(/uniform\s+vec3\s+u_color_levels/u)
 	})
 })
 
@@ -334,12 +334,14 @@ describe('UPSCALE shader source', () => {
 
 	it('samples all 4 axis-aligned neighbours for the dot-blend', () => {
 		// 1 center + 4 neighbours = at least 5 texture2D calls
-		const sample_count = (UPSCALE_FRAGMENT_SHADER.match(/texture2D\(\s*u_lo_tex/g) ?? []).length
+		const sample_count = (UPSCALE_FRAGMENT_SHADER.match(/texture2D\(\s*u_lo_tex/gu) ?? []).length
 		expect(sample_count).toBeGreaterThanOrEqual(5)
 	})
 
 	it('mixes center with neighbour average using u_dot_blend', () => {
-		expect(UPSCALE_FRAGMENT_SHADER).toMatch(/mix\(\s*center\s*,\s*neighbors\s*,\s*u_dot_blend\s*\)/)
+		expect(UPSCALE_FRAGMENT_SHADER).toMatch(
+			/mix\(\s*center\s*,\s*neighbors\s*,\s*u_dot_blend\s*\)/u,
+		)
 	})
 })
 
@@ -357,27 +359,27 @@ describe('SCANLINE shader source', () => {
 	})
 
 	it('projects pixel coordinate onto u_scanline_axis (portrait/landscape flip)', () => {
-		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/dot\(\s*pixel\s*,\s*u_scanline_axis\s*\)/)
+		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/dot\(\s*pixel\s*,\s*u_scanline_axis\s*\)/u)
 	})
 
 	it('applies smooth cosine profile (no hard step — eliminates moiré with pixel-art grid)', () => {
 		expect(SCANLINE_FRAGMENT_SHADER).toContain('cos(')
 		expect(SCANLINE_FRAGMENT_SHADER).not.toContain('step(')
-		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/mix\(\s*u_scanline_dark\s*,\s*1\.0\s*,\s*wave\s*\)/)
+		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/mix\(\s*u_scanline_dark\s*,\s*1\.0\s*,\s*wave\s*\)/u)
 	})
 
 	it('declares u_scanline_sharpness uniform and applies pow() to the cosine wave', () => {
 		expect(SCANLINE_FRAGMENT_SHADER).toContain('u_scanline_sharpness')
-		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/pow\(\s*wave_cos\s*,\s*u_scanline_sharpness\s*\)/)
+		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/pow\(\s*wave_cos\s*,\s*u_scanline_sharpness\s*\)/u)
 	})
 
 	it('declares u_bleed and samples neighbors at ±half_period for phosphor glow', () => {
 		expect(SCANLINE_FRAGMENT_SHADER).toContain('u_bleed')
 		// Two neighbor samples offset along the scanline axis
-		const samples = (SCANLINE_FRAGMENT_SHADER.match(/texture2D\(\s*tDiffuse/g) ?? []).length
+		const samples = (SCANLINE_FRAGMENT_SHADER.match(/texture2D\(\s*tDiffuse/gu) ?? []).length
 		expect(samples).toBeGreaterThanOrEqual(3)
 		// Bleed attenuates with (1 - wave) so dark bands get max glow, bright bands get none
-		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/\(\s*1\.0\s*-\s*wave\s*\)/)
+		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/\(\s*1\.0\s*-\s*wave\s*\)/u)
 		expect(SCANLINE_FRAGMENT_SHADER).toContain('half_period_uv')
 	})
 })

--- a/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
@@ -80,37 +80,37 @@ describe('ScoreDisplay', () => {
 describe('ScoreDisplay font selection — driven by CRT-aware fonts helpers, not by is_alt (CYBER)', () => {
 	it('current_font uses fonts.get_active_font() (no caller-supplied flag)', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_active_font\(\s*\)\s*\)/,
+			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_active_font\(\s*\)\s*\)/u,
 		)
 	})
 
 	it('font_size_multiplier uses fonts.get_active_font_size_multiplier()', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_active_font_size_multiplier\(\s*\)\s*\)/,
+			/let\s+font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_active_font_size_multiplier\(\s*\)\s*\)/u,
 		)
 	})
 
 	it('no longer derives a local should_use_alt_font (CRT awareness lives in fonts.ts)', () => {
-		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/\bshould_use_alt_font\b/)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/\bshould_use_alt_font\b/u)
 	})
 
 	it('no longer imports crt directly (consumer is decoupled from CRT module)', () => {
 		expect(SCORE_DISPLAY_SOURCE).not.toMatch(
-			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/,
+			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/u,
 		)
-		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/\bcrt\.is_crt_enabled\b/)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/\bcrt\.is_crt_enabled\b/u)
 	})
 
 	it('keeps is_alt prop driving palette decisions (panel/label/value colors)', () => {
-		expect(SCORE_DISPLAY_SOURCE).toMatch(/let\s+panel_color\s*=\s*\$derived\(\s*is_alt\s*\?/)
+		expect(SCORE_DISPLAY_SOURCE).toMatch(/let\s+panel_color\s*=\s*\$derived\(\s*is_alt\s*\?/u)
 	})
 
 	it('does not pass is_alt into any fonts helper (font axis is CRT, not CYBER)', () => {
-		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
-		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/)
-		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_active_font\(\s*is_alt\s*\)/)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/u)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/u)
+		expect(SCORE_DISPLAY_SOURCE).not.toMatch(/fonts\.get_active_font\(\s*is_alt\s*\)/u)
 		expect(SCORE_DISPLAY_SOURCE).not.toMatch(
-			/fonts\.get_active_font_size_multiplier\(\s*is_alt\s*\)/,
+			/fonts\.get_active_font_size_multiplier\(\s*is_alt\s*\)/u,
 		)
 	})
 })
@@ -118,11 +118,11 @@ describe('ScoreDisplay font selection — driven by CRT-aware fonts helpers, not
 describe('ScoreDisplay panel tilt — root group rotates by PANEL_TILT_X for a downward angle', () => {
 	it('imports PANEL_TILT_X from score-display-config', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/import\s*\{[\s\S]*\bPANEL_TILT_X\b[\s\S]*\}\s*from\s*'\$lib\/game-kit\/display\/score-display-config'/,
+			/import\s*\{[\s\S]*\bPANEL_TILT_X\b[\s\S]*\}\s*from\s*'\$lib\/game-kit\/display\/score-display-config'/u,
 		)
 	})
 
 	it('root <T.Group> applies rotation.x={PANEL_TILT_X}', () => {
-		expect(SCORE_DISPLAY_SOURCE).toMatch(/<T\.Group[^>]*\brotation\.x=\{PANEL_TILT_X\}[^>]*>/)
+		expect(SCORE_DISPLAY_SOURCE).toMatch(/<T\.Group[^>]*\brotation\.x=\{PANEL_TILT_X\}[^>]*>/u)
 	})
 })

--- a/src/lib/game-kit/fonts.test.ts
+++ b/src/lib/game-kit/fonts.test.ts
@@ -11,11 +11,11 @@ describe('fonts', () => {
 	})
 
 	it('get_font returns a local font path for retro selection', () => {
-		expect(fonts.get_font(false)).toMatch(/^\/fonts\//)
+		expect(fonts.get_font(false)).toMatch(/^\/fonts\//u)
 	})
 
 	it('get_font returns a local font path for alt selection', () => {
-		expect(fonts.get_font(true)).toMatch(/^\/fonts\//)
+		expect(fonts.get_font(true)).toMatch(/^\/fonts\//u)
 	})
 
 	it('get_font returns the retro pixel font for should_use_alt_font=false', () => {

--- a/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
+++ b/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
@@ -46,27 +46,27 @@ describe('FloorCredits', () => {
 describe('FloorCredits font selection — driven by CRT, not CYBER (is_alt)', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled', () => {
 		expect(FLOOR_CREDITS_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/,
+			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('current_font passes should_use_alt_font into fonts.get_font (not is_alt)', () => {
 		expect(FLOOR_CREDITS_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/,
+			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 	})
 
 	it('imports crt from $lib/game-kit/crt.svelte', () => {
 		expect(FLOOR_CREDITS_SOURCE).toMatch(
-			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/,
+			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/u,
 		)
 	})
 
 	it('keeps is_alt prop driving the credits color (CYBER vs normal)', () => {
-		expect(FLOOR_CREDITS_SOURCE).toMatch(/let\s+color\s*=\s*\$derived\(\s*is_alt\s*\?/)
+		expect(FLOOR_CREDITS_SOURCE).toMatch(/let\s+color\s*=\s*\$derived\(\s*is_alt\s*\?/u)
 	})
 
 	it('does not pass is_alt directly into fonts helpers', () => {
-		expect(FLOOR_CREDITS_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
+		expect(FLOOR_CREDITS_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/u)
 	})
 })

--- a/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
+++ b/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
@@ -125,30 +125,30 @@ describe('SceneObjects', () => {
 describe('SceneObjects font selection — driven by CRT, not CYBER (is_alt)', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled (font swaps with CRT, not CYBER)', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/,
+			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('current_font passes should_use_alt_font into fonts.get_font (not is_alt)', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/,
+			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 	})
 
 	it('current_font_size_multiplier passes should_use_alt_font into fonts.get_font_size_multiplier', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/let\s+current_font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)\s*\)/,
+			/let\s+current_font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 	})
 
 	it('imports crt from $lib/game-kit/crt.svelte so the derived can read is_crt_enabled', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/,
+			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/u,
 		)
 	})
 
 	it('does not pass is_alt directly into fonts helpers (font is no longer CYBER-driven)', () => {
-		expect(SCENE_OBJECTS_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
-		expect(SCENE_OBJECTS_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/)
+		expect(SCENE_OBJECTS_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/u)
+		expect(SCENE_OBJECTS_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/u)
 	})
 })

--- a/src/lib/game-kit/scene/credits-config.test.ts
+++ b/src/lib/game-kit/scene/credits-config.test.ts
@@ -33,11 +33,11 @@ describe('credits-config', () => {
 	})
 
 	it('CREDITS_NORMAL_COLOR is a valid hex color', () => {
-		expect(CREDITS_NORMAL_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/)
+		expect(CREDITS_NORMAL_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/u)
 	})
 
 	it('CREDITS_CYBER_COLOR is a valid hex color', () => {
-		expect(CREDITS_CYBER_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/)
+		expect(CREDITS_CYBER_COLOR).toMatch(/^#[0-9a-fA-F]{6}$/u)
 	})
 
 	it('CREDITS_NORMAL_COLOR and CREDITS_CYBER_COLOR are distinct', () => {

--- a/src/lib/game-kit/switch/Switch.svelte.test.ts
+++ b/src/lib/game-kit/switch/Switch.svelte.test.ts
@@ -107,26 +107,26 @@ describe('Switch — panel_text material (matches the border frame glow)', () =>
 	// frame ("枠") so the digits glow at matching brightness.
 
 	it('imports MeshStandardMaterial from three', () => {
-		expect(SWITCH_SOURCE).toMatch(/import\s*\{[^}]*MeshStandardMaterial[^}]*\}\s*from\s*'three'/)
+		expect(SWITCH_SOURCE).toMatch(/import\s*\{[^}]*MeshStandardMaterial[^}]*\}\s*from\s*'three'/u)
 	})
 
 	it('constructs a MeshStandardMaterial for panel_text', () => {
-		expect(SWITCH_SOURCE).toMatch(/new\s+MeshStandardMaterial\(/)
+		expect(SWITCH_SOURCE).toMatch(/new\s+MeshStandardMaterial\(/u)
 		// The result must be stored in a binding referenced by the Text tag (see below).
-		expect(SWITCH_SOURCE).toMatch(/panel_text_material/)
+		expect(SWITCH_SOURCE).toMatch(/panel_text_material/u)
 	})
 
 	it('syncs the material color and emissive to the resolved border-frame values', () => {
 		// Color = border color, emissive = border color, intensity = ring_emissive
 		// (= same emissive intensity as the border frame).
 		expect(SWITCH_SOURCE).toMatch(
-			/panel_text_material\.color\.set\(\s*resolved\.current_color\s*\)/,
+			/panel_text_material\.color\.set\(\s*resolved\.current_color\s*\)/u,
 		)
 		expect(SWITCH_SOURCE).toMatch(
-			/panel_text_material\.emissive\.set\(\s*resolved\.current_color\s*\)/,
+			/panel_text_material\.emissive\.set\(\s*resolved\.current_color\s*\)/u,
 		)
 		expect(SWITCH_SOURCE).toMatch(
-			/panel_text_material\.emissiveIntensity\s*=\s*resolved\.ring_emissive/,
+			/panel_text_material\.emissiveIntensity\s*=\s*resolved\.ring_emissive/u,
 		)
 	})
 
@@ -134,11 +134,11 @@ describe('Switch — panel_text material (matches the border frame glow)', () =>
 		// panel_text Text must receive material={...}; the prior `color=` prop must be gone
 		// so the material's color/emissive own the appearance.
 		expect(SWITCH_SOURCE).toMatch(
-			/text=\{\s*panel_text\s*\}[\s\S]*?material=\{\s*panel_text_material\s*\}/,
+			/text=\{\s*panel_text\s*\}[\s\S]*?material=\{\s*panel_text_material\s*\}/u,
 		)
 	})
 
 	it('disposes the material on unmount', () => {
-		expect(SWITCH_SOURCE).toMatch(/onDestroy\([\s\S]*panel_text_material\.dispose\(\)/)
+		expect(SWITCH_SOURCE).toMatch(/onDestroy\([\s\S]*panel_text_material\.dispose\(\)/u)
 	})
 })

--- a/src/lib/game/Board.svelte.test.ts
+++ b/src/lib/game/Board.svelte.test.ts
@@ -69,31 +69,31 @@ describe('Board', () => {
 describe('Board font selection — driven by CRT, not CYBER (is_alt)', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/,
+			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('current_font and current_font_size use should_use_alt_font (not is_alt)', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/,
+			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
-		expect(BOARD_SOURCE).toMatch(/fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)/)
+		expect(BOARD_SOURCE).toMatch(/fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)/u)
 	})
 
 	it('imports crt from $lib/game-kit/crt.svelte', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/,
+			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/u,
 		)
 	})
 
 	it('keeps is_alt prop driving button palette (lit/dim color helpers)', () => {
-		expect(BOARD_SOURCE).toMatch(/return\s+is_alt\s*\?\s*btn\.cyber_lit_color/)
-		expect(BOARD_SOURCE).toMatch(/return\s+is_alt\s*\?\s*btn\.cyber_dim_color/)
+		expect(BOARD_SOURCE).toMatch(/return\s+is_alt\s*\?\s*btn\.cyber_lit_color/u)
+		expect(BOARD_SOURCE).toMatch(/return\s+is_alt\s*\?\s*btn\.cyber_dim_color/u)
 	})
 
 	it('does not pass is_alt directly into fonts helpers', () => {
-		expect(BOARD_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
-		expect(BOARD_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/)
+		expect(BOARD_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/u)
+		expect(BOARD_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/u)
 	})
 })
 
@@ -101,29 +101,29 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 	it('FONT_SIZE is pinned to 0.13 — bumped for a larger single-line START label', () => {
 		// Reason: FONT_SIZE drives the START / idle label only; pin the literal value
 		// so the requested size bump is not silently undone.
-		expect(BOARD_SOURCE).toMatch(/const\s+FONT_SIZE\s*=\s*0\.13\b/)
+		expect(BOARD_SOURCE).toMatch(/const\s+FONT_SIZE\s*=\s*0\.13\b/u)
 	})
 
 	it('MULTILINE_FONT_SIZE is pinned to 0.16 — per-line size used by the 2-line GAME OVER label', () => {
 		// Reason: GAME OVER is the only 2-line center label; pin the per-line size so
 		// the relative hierarchy with START (single-line) is preserved.
-		expect(BOARD_SOURCE).toMatch(/const\s+MULTILINE_FONT_SIZE\s*=\s*0\.16\b/)
+		expect(BOARD_SOURCE).toMatch(/const\s+MULTILINE_FONT_SIZE\s*=\s*0\.16\b/u)
 	})
 
 	it('ROUND_DIGIT_FONT_SIZE is pinned to 0.2 — size for the digit-only ROUND display', () => {
 		// Reason: during a round the center shows just the round number, which is the
 		// focal info during play; pin the literal so it stays at the chosen prominence.
-		expect(BOARD_SOURCE).toMatch(/const\s+ROUND_DIGIT_FONT_SIZE\s*=\s*0\.2\b/)
+		expect(BOARD_SOURCE).toMatch(/const\s+ROUND_DIGIT_FONT_SIZE\s*=\s*0\.2\b/u)
 	})
 
 	it('MULTILINE_LINE_HEIGHT is pinned to 1.4 — gives GAME / OVER a little breathing room', () => {
-		expect(BOARD_SOURCE).toMatch(/const\s+MULTILINE_LINE_HEIGHT\s*=\s*1\.4\b/)
+		expect(BOARD_SOURCE).toMatch(/const\s+MULTILINE_LINE_HEIGHT\s*=\s*1\.4\b/u)
 	})
 
 	it('center font sizes follow the intended hierarchy: ROUND_DIGIT > MULTILINE > FONT_SIZE', () => {
-		const fz = BOARD_SOURCE.match(/const\s+FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/)
-		const ml = BOARD_SOURCE.match(/const\s+MULTILINE_FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/)
-		const rd = BOARD_SOURCE.match(/const\s+ROUND_DIGIT_FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/)
+		const fz = BOARD_SOURCE.match(/const\s+FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/u)
+		const ml = BOARD_SOURCE.match(/const\s+MULTILINE_FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/u)
+		const rd = BOARD_SOURCE.match(/const\s+ROUND_DIGIT_FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/u)
 		expect(fz).not.toBeNull()
 		expect(ml).not.toBeNull()
 		expect(rd).not.toBeNull()
@@ -132,35 +132,35 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 	})
 
 	it('GAME OVER text is split into two lines by replacing its space with a newline', () => {
-		expect(BOARD_SOURCE).toMatch(/text_gameover\.replace\(\s*['"`] ['"`]\s*,\s*['"`]\\n['"`]\s*\)/)
+		expect(BOARD_SOURCE).toMatch(/text_gameover\.replace\(\s*['"`] ['"`]\s*,\s*['"`]\\n['"`]\s*\)/u)
 	})
 
 	it('ROUND state renders only the round number (no label prefix, no newline)', () => {
-		expect(BOARD_SOURCE).toMatch(/return\s+String\(\s*game_data\.round\s*\)/)
+		expect(BOARD_SOURCE).toMatch(/return\s+String\(\s*game_data\.round\s*\)/u)
 		// Sanity: the old "label\nnumber" template should be gone.
-		expect(BOARD_SOURCE).not.toMatch(/`\$\{text_round\}\\n\$\{game_data\.round\}`/)
+		expect(BOARD_SOURCE).not.toMatch(/`\$\{text_round\}\\n\$\{game_data\.round\}`/u)
 	})
 
 	it('is_multiline_center is true only for the gameover phase (round display is single-line)', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/is_multiline_center\s*=\s*\$derived\(\s*game_data\.phase\s*===\s*['"]gameover['"]\s*\)/,
+			/is_multiline_center\s*=\s*\$derived\(\s*game_data\.phase\s*===\s*['"]gameover['"]\s*\)/u,
 		)
 	})
 
 	it('center base font size has a 3-way selection (gameover → MULTILINE, round>0 → ROUND_DIGIT, else → FONT_SIZE)', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/function\s+get_center_base_font_size\(\)\s*:\s*number\s*\{[\s\S]*MULTILINE_FONT_SIZE[\s\S]*ROUND_DIGIT_FONT_SIZE[\s\S]*FONT_SIZE[\s\S]*\}/,
+			/function\s+get_center_base_font_size\(\)\s*:\s*number\s*\{[\s\S]*MULTILINE_FONT_SIZE[\s\S]*ROUND_DIGIT_FONT_SIZE[\s\S]*FONT_SIZE[\s\S]*\}/u,
 		)
 		expect(BOARD_SOURCE).toMatch(
-			/center_base_font_size\s*=\s*\$derived\(\s*get_center_base_font_size\(\)\s*\)/,
+			/center_base_font_size\s*=\s*\$derived\(\s*get_center_base_font_size\(\)\s*\)/u,
 		)
 	})
 
 	it('Text component receives lineHeight={current_line_height} so GAME OVER gets extra spacing', () => {
-		expect(BOARD_SOURCE).toMatch(/<Text[\s\S]*lineHeight=\{current_line_height\}[\s\S]*\/>/)
+		expect(BOARD_SOURCE).toMatch(/<Text[\s\S]*lineHeight=\{current_line_height\}[\s\S]*\/>/u)
 		// Whitespace-normalized substring check avoids the long chain of `\s*` separators
 		// (SonarCloud rule typescript:S5852 flags such patterns as ReDoS candidates).
-		const normalized = BOARD_SOURCE.replace(/\s+/g, ' ')
+		const normalized = BOARD_SOURCE.replace(/\s+/gu, ' ')
 		expect(normalized).toContain(
 			'current_line_height = $derived( is_multiline_center ? MULTILINE_LINE_HEIGHT : SINGLE_LINE_HEIGHT',
 		)
@@ -170,18 +170,18 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 describe('templates Board mirrors the CRT-driven font behavior', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled', () => {
 		expect(TEMPLATE_BOARD_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/,
+			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('imports crt from @joshuafolkken/game-kit', () => {
 		expect(TEMPLATE_BOARD_SOURCE).toMatch(
-			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'@joshuafolkken\/game-kit'/,
+			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'@joshuafolkken\/game-kit'/u,
 		)
 	})
 
 	it('does not pass is_alt directly into fonts helpers', () => {
-		expect(TEMPLATE_BOARD_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/)
-		expect(TEMPLATE_BOARD_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/)
+		expect(TEMPLATE_BOARD_SOURCE).not.toMatch(/fonts\.get_font\(\s*is_alt\s*\)/u)
+		expect(TEMPLATE_BOARD_SOURCE).not.toMatch(/fonts\.get_font_size_multiplier\(\s*is_alt\s*\)/u)
 	})
 })

--- a/src/routes/page-features.e2e.ts
+++ b/src/routes/page-features.e2e.ts
@@ -84,7 +84,7 @@ test('pseudo-fullscreen class is applied when native API is unavailable on touch
 		scene.click()
 	})
 
-	await expect(page.locator('[data-testid="game-scene"]')).toHaveClass(/pseudo-fullscreen/)
+	await expect(page.locator('[data-testid="game-scene"]')).toHaveClass(/pseudo-fullscreen/u)
 })
 
 test('page has no critical or serious accessibility violations', async ({ page }) => {


### PR DESCRIPTION
## Scope

**PR-2 of multi-PR migration** addressing #188 (continues PR-1 #189).

Removes `'require-unicode-regexp': 'off'` from the `PR1_TEMPORARY_RULE_DISABLES` backlog in [eslint.config.js](eslint.config.js) and fixes all 244 violations by adding the `u` (unicode) flag to every regex literal and `new RegExp(...)` invocation in `src/`.

## Why manual (no `eslint --fix`)

The `require-unicode-regexp` rule in this version of typescript-eslint does NOT expose an auto-fix (verified via the rule's `fix` field being `null` in ESLint's JSON output). A Node script using ESLint's reported line/column data was used to inject the `u` flag at exact positions, walking each regex literal forward through any `[...]` character classes and `\/` escapes to find the closing delimiter, then re-sorting the resulting flag set canonically (d-g-i-m-s-u-y). 3 `new RegExp(string, ...)` invocations were fixed manually (the rule's location pointed to the `new` keyword, not a regex literal).

## Risk assessment

Adding the `u` flag to a regex CAN change behavior in two cases:
1. Patterns that relied on lone surrogates or invalid escape sequences (rare; would have thrown under strict `u` mode)
2. `\p{}` / `\P{}` Unicode property escapes that only work under `u`

Verified safe: all 1065 unit tests pass unchanged. The regexes here are all source-shape regression assertions (matching CSS / TypeScript source text); none rely on lone-surrogate or invalid-escape patterns.

## Acceptance criteria status

This PR partially addresses **#188**:

- [x] One rule removed from `PR1_TEMPORARY_RULE_DISABLES` (require-unicode-regexp)
- [x] All 244 violations of that rule fixed
- [x] `pnpm josh lint` exits 0
- [x] `pnpm exec tsc --noEmit` exits 0
- [x] `pnpm josh cspell:dot` exits 0
- [x] `pnpm josh test:unit` — all 1065 tests pass
- [ ] All disables removed (tracked under #188; PR-3+ continues per category)

**#188 stays open** until every TODO disable in `eslint.config.js` is removed.

## Test plan

- [x] Lint / tsc / cspell / unit all green locally
- [ ] E2E (`pnpm josh test`) — user-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)