### PR TITLE
PR-5 of strict eslint migration: enforce padding-line-between-statements (blank-line formatting) #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -115,9 +115,6 @@ const PR1_TEMPORARY_RULE_DISABLES = {
 	'unicorn/no-array-reverse': 'off',
 	// TODO #188 follow-up: tighten unknown-type return sites
 	'@typescript-eslint/no-unsafe-return': 'off',
-	// TODO #188 follow-up: add canonical blank lines between statements
-	'padding-line-between-statements': 'off',
-	'@stylistic/padding-line-between-statements': 'off',
 	// TODO #188 follow-up: convert `let` to `const` where never reassigned
 	'prefer-const': 'off',
 	// TODO #188 follow-up: simplify regex literals to their canonical form

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.81.0",
+	"version": "0.82.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -16,21 +16,25 @@ function make_resolve(): ResolveFn {
 describe('inject_game_name', () => {
 	it('replaces __GAME_NAME__ with the all-caps game name', () => {
 		const html = '<p class="game-title">__GAME_NAME__</p>'
+
 		expect(inject_game_name(html)).toBe('<p class="game-title">JOSHUA GAME</p>')
 	})
 
 	it('replaces __GAME_NAME_DISPLAY__ with the title-case game name', () => {
 		const html = '<title>__GAME_NAME_DISPLAY__</title>'
+
 		expect(inject_game_name(html)).toBe('<title>Joshua Game</title>')
 	})
 
 	it('replaces __GAME_NAME_DISPLAY__ before __GAME_NAME__ to avoid partial match', () => {
 		const html = '__GAME_NAME_DISPLAY__ and __GAME_NAME__'
+
 		expect(inject_game_name(html)).toBe('Joshua Game and JOSHUA GAME')
 	})
 
 	it('passes through html with no placeholders', () => {
 		const html = '<p>no placeholder here</p>'
+
 		expect(inject_game_name(html)).toBe(html)
 	})
 })
@@ -38,16 +42,19 @@ describe('inject_game_name', () => {
 describe('inject_version', () => {
 	it('replaces the placeholder with the package version', () => {
 		const html = '<p class="game-version">v__APP_VERSION__</p>'
+
 		expect(inject_version(html)).toBe(`<p class="game-version">v${version}</p>`)
 	})
 
 	it('replaces all occurrences of the placeholder', () => {
 		const html = '__APP_VERSION__ and __APP_VERSION__'
+
 		expect(inject_version(html)).toBe(`${version} and ${version}`)
 	})
 
 	it('passes through html that has no placeholder', () => {
 		const html = '<p>no placeholder here</p>'
+
 		expect(inject_version(html)).toBe(html)
 	})
 })
@@ -55,22 +62,26 @@ describe('inject_version', () => {
 describe('handle', () => {
 	it('adds X-Frame-Options: SAMEORIGIN', async () => {
 		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+
 		expect(response.headers.get('x-frame-options')).toBe('SAMEORIGIN')
 	})
 
 	it('adds X-Content-Type-Options: nosniff', async () => {
 		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+
 		expect(response.headers.get('x-content-type-options')).toBe('nosniff')
 	})
 
 	it('adds Referrer-Policy: strict-origin-when-cross-origin', async () => {
 		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+
 		expect(response.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin')
 	})
 
 	it('adds Permissions-Policy restricting camera, microphone, geolocation, payment', async () => {
 		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
 		const policy = response.headers.get('permissions-policy')
+
 		expect(policy).toContain('camera=()')
 		expect(policy).toContain('microphone=()')
 		expect(policy).toContain('geolocation=()')
@@ -80,6 +91,7 @@ describe('handle', () => {
 	it("adds Content-Security-Policy with default-src 'self'", async () => {
 		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
 		const csp = response.headers.get('content-security-policy')
+
 		expect(csp).toContain("default-src 'self'")
 		expect(csp).toContain("object-src 'none'")
 		expect(csp).toContain("frame-ancestors 'self'")
@@ -89,10 +101,13 @@ describe('handle', () => {
 		let captured_transform: ResolveOptions['transformPageChunk'] | undefined
 		const resolve = vi.fn<ResolveFn>().mockImplementation((_event, opts) => {
 			captured_transform = opts?.transformPageChunk
+
 			return Promise.resolve(new Response(null, { status: 200 }))
 		})
+
 		await handle({ event: {} as RequestEvent, resolve })
 		const result = await captured_transform?.({ html: 'v__APP_VERSION__', done: true })
+
 		expect(result).toBe(`v${version}`)
 	})
 })

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -45,6 +45,8 @@ export const handle: Handle = async function handle({ event, resolve }) {
 			return inject_game_name(inject_version(html))
 		},
 	})
+
 	inject_security_headers(response)
+
 	return response
 }

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -4,6 +4,7 @@
 
 	function generate_filter_id(): string {
 		next_filter_id += 1
+
 		return `${FILTER_ID_PREFIX}-${next_filter_id}`
 	}
 </script>

--- a/src/lib/components/Logo.svelte.test.ts
+++ b/src/lib/components/Logo.svelte.test.ts
@@ -12,6 +12,7 @@ describe('Logo', () => {
 	it('renders an svg with the expected viewBox', () => {
 		const { container } = render(Logo)
 		const svg = container.querySelector('svg')
+
 		expect(svg).toBeTruthy()
 		expect(svg?.getAttribute('viewBox')).toBe(EXPECTED_VIEW_BOX)
 	})
@@ -19,24 +20,28 @@ describe('Logo', () => {
 	it('uses the default size when no prop is given', () => {
 		const { container } = render(Logo)
 		const svg = container.querySelector('svg')
+
 		expect(svg?.getAttribute('width')).toBe(DEFAULT_SIZE_STRING)
 	})
 
 	it('reflects the size prop on the width attribute', () => {
 		const { container } = render(Logo, { size: CUSTOM_SIZE })
 		const svg = container.querySelector('svg')
+
 		expect(svg?.getAttribute('width')).toBe(String(CUSTOM_SIZE))
 	})
 
 	it('uses the default aria-label when no prop is given', () => {
 		const { container } = render(Logo)
 		const svg = container.querySelector('svg')
+
 		expect(svg?.getAttribute('aria-label')).toBe(DEFAULT_ARIA_LABEL)
 	})
 
 	it('reflects the aria_label prop on the aria-label attribute', () => {
 		const { container } = render(Logo, { aria_label: CUSTOM_ARIA_LABEL })
 		const svg = container.querySelector('svg')
+
 		expect(svg?.getAttribute('aria-label')).toBe(CUSTOM_ARIA_LABEL)
 	})
 
@@ -45,6 +50,7 @@ describe('Logo', () => {
 		const second = render(Logo)
 		const first_id = first.container.querySelector('filter')?.getAttribute('id')
 		const second_id = second.container.querySelector('filter')?.getAttribute('id')
+
 		expect(first_id).toBeTruthy()
 		expect(second_id).toBeTruthy()
 		expect(first_id).not.toBe(second_id)

--- a/src/lib/game-kit/CrtChromaticFilter.svelte.test.ts
+++ b/src/lib/game-kit/CrtChromaticFilter.svelte.test.ts
@@ -18,6 +18,7 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 		const offset_count = (CRT_CHROMATIC_FILTER_SOURCE.match(/<feOffset\b/gu) ?? []).length
 		const REQUIRED_CHANNEL_MATRICES = 3
 		const REQUIRED_OFFSETS = 2
+
 		expect(color_matrix_count).toBe(REQUIRED_CHANNEL_MATRICES)
 		expect(offset_count).toBe(REQUIRED_OFFSETS)
 	})
@@ -35,15 +36,18 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 		const b_match = CRT_CHROMATIC_FILTER_SOURCE.match(
 			/<feOffset[^>]*\sin="b_only"[^>]*\sdx="(-?\d+(?:\.\d+)?)"[^>]*\sdy="0"/u,
 		)
+
 		expect(r_match).toBeTruthy()
 		expect(b_match).toBeTruthy()
 		const r_dx_str = r_match?.[1]
 		const b_dx_str = b_match?.[1]
+
 		expect(r_dx_str).toBeDefined()
 		expect(b_dx_str).toBeDefined()
 		if (r_dx_str === undefined || b_dx_str === undefined) return
 		const r_dx = parseFloat(r_dx_str)
 		const b_dx = parseFloat(b_dx_str)
+
 		expect(r_dx).not.toBe(0)
 		expect(r_dx).toBe(-b_dx)
 	})
@@ -56,6 +60,7 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 			CRT_CHROMATIC_FILTER_SOURCE.match(/<feComposite[^>]*operator="arithmetic"/gu) ?? []
 		).length
 		const REQUIRED_COMPOSITES = 2
+
 		expect(composite_count).toBe(REQUIRED_COMPOSITES)
 		expect(CRT_CHROMATIC_FILTER_SOURCE).toMatch(/k1="0"\s+k2="1"\s+k3="1"\s+k4="0"/u)
 	})
@@ -63,6 +68,7 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 	it('renders the SVG <filter id="crt-chromatic"> into the DOM when mounted standalone', () => {
 		const { container } = render(CrtChromaticFilter)
 		const filter = container.querySelector('#crt-chromatic')
+
 		expect(filter).toBeTruthy()
 		expect(filter?.tagName.toLowerCase()).toBe('filter')
 	})

--- a/src/lib/game-kit/CrtDitherPass.svelte
+++ b/src/lib/game-kit/CrtDitherPass.svelte
@@ -148,8 +148,10 @@
 				ctx.renderer.setPixelRatio(ctx.dpr.current)
 				ctx.renderer.setSize(ctx.size.current.width, ctx.size.current.height)
 				ctx.renderer.render(ctx.scene, ctx.camera.current)
+
 				return
 			}
+
 			// Stage 1: render game + dither at low resolution.
 			lo_composer.setSize(ctx.size.current.width, ctx.size.current.height)
 			lo_composer.setPixelRatio(lo_dpr)
@@ -158,6 +160,7 @@
 			// hi_lo_ratio and guards against (0,0) reaching u_lo_resolution in the shader.
 			const lo_w = Math.max(1, Math.floor(ctx.size.current.width * lo_dpr))
 			const lo_h = Math.max(1, Math.floor(ctx.size.current.height * lo_dpr))
+
 			dither_uniforms.u_resolution.value.set(lo_w, lo_h)
 			upscale_uniforms.u_lo_resolution.value.set(lo_w, lo_h)
 			lo_composer.render(delta)
@@ -173,19 +176,23 @@
 			scanline_uniforms.u_resolution.value.copy(hi_drawing_buf)
 			// Scale scanline period so one cycle spans one virtual lo-res dot row.
 			const is_portrait = hi_drawing_buf.x < hi_drawing_buf.y
+
 			scanline_uniforms.u_scanline_axis.value.set(is_portrait ? 1 : 0, is_portrait ? 0 : 1)
+
 			if (lo_h > 0) {
 				const hi_lo_ratio = is_portrait ? hi_drawing_buf.x / lo_w : hi_drawing_buf.y / lo_h
 				const period = Math.max(
 					DOTS_PER_SCANLINE * SCANLINE_PHASES_PER_CYCLE,
 					Math.round(DOTS_PER_SCANLINE * SCANLINE_PHASES_PER_CYCLE * hi_lo_ratio),
 				)
+
 				scanline_uniforms.u_scanline_period.value = period
 				scanline_uniforms.u_bleed.value = Math.min(
 					SCANLINE_BLEED,
 					(SCANLINE_BLEED * period) / SCANLINE_BLEED_FULL_PERIOD,
 				)
 			}
+
 			barrel_uniforms.u_aspect.value =
 				hi_drawing_buf.y > 0 ? hi_drawing_buf.x / hi_drawing_buf.y : 1
 			hi_composer.render(delta)

--- a/src/lib/game-kit/CrtDitherPass.svelte.test.ts
+++ b/src/lib/game-kit/CrtDitherPass.svelte.test.ts
@@ -54,6 +54,7 @@ describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 		const render_idx = CRT_DITHER_PASS_SOURCE.indexOf('lo_composer.addPass(render_pass)')
 		const output_idx = CRT_DITHER_PASS_SOURCE.indexOf('lo_composer.addPass(output_pass)')
 		const dither_idx = CRT_DITHER_PASS_SOURCE.indexOf('lo_composer.addPass(dither_pass)')
+
 		expect(render_idx).toBeGreaterThan(-1)
 		expect(output_idx).toBeGreaterThan(-1)
 		expect(dither_idx).toBeGreaterThan(-1)
@@ -66,6 +67,7 @@ describe('CrtDitherPass.svelte — EffectComposer wiring', () => {
 		const upscale_idx = CRT_DITHER_PASS_SOURCE.indexOf('hi_composer.addPass(upscale_pass)')
 		const scanline_idx = CRT_DITHER_PASS_SOURCE.indexOf('hi_composer.addPass(scanline_pass)')
 		const barrel_idx = CRT_DITHER_PASS_SOURCE.indexOf('hi_composer.addPass(barrel_pass)')
+
 		expect(upscale_idx).toBeGreaterThan(-1)
 		expect(scanline_idx).toBeGreaterThan(-1)
 		expect(barrel_idx).toBeGreaterThan(-1)

--- a/src/lib/game-kit/GameScene.svelte
+++ b/src/lib/game-kit/GameScene.svelte
@@ -114,8 +114,10 @@
 				event.preventDefault()
 				session.reset_session()
 			}
+
 			return
 		}
+
 		if (event.key !== 'Enter') return
 		event.preventDefault()
 		start_game()
@@ -134,6 +136,7 @@
 			console.warn('[GameScene] No <canvas> found at mount — synthetic pointer events disabled')
 		const cleanup_input = input.setup_listeners(canvas_el)
 		const cleanup_fullscreen = fullscreen.setup_listeners()
+
 		return function cleanup(): void {
 			cleanup_input()
 			cleanup_fullscreen()

--- a/src/lib/game-kit/GameScene.svelte.test.ts
+++ b/src/lib/game-kit/GameScene.svelte.test.ts
@@ -39,22 +39,26 @@ describe('GameScene', () => {
 
 	it('renders game-scene container', () => {
 		const { container } = render_scene()
+
 		expect(container.querySelector('[data-testid="game-scene"]')).toBeTruthy()
 	})
 
 	it('hides jump button before the session starts', () => {
 		const { container } = render_scene()
+
 		expect(container.querySelector('[data-testid="jump-btn"]')).toBeNull()
 	})
 
 	it('shows jump button with aria-label after session starts', () => {
 		const { container } = render_scene()
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		scene.click()
 		flushSync()
 		const btn = container.querySelector<HTMLElement>('[data-testid="jump-btn"]')
+
 		expect(btn).toBeTruthy()
 		expect(btn?.getAttribute('aria-label')).toBe(LABEL_JUMP)
 		expect(btn?.querySelector('svg')).toBeTruthy()
@@ -62,6 +66,7 @@ describe('GameScene', () => {
 
 	it('renders a canvas element', () => {
 		const { container } = render_scene()
+
 		expect(container.querySelector('canvas')).toBeTruthy()
 	})
 
@@ -88,6 +93,7 @@ describe('GameScene', () => {
 			},
 		})
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		scene.click()
@@ -102,6 +108,7 @@ describe('GameScene', () => {
 			},
 		})
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		scene.click()
@@ -114,6 +121,7 @@ describe('GameScene', () => {
 		const spy = vi.spyOn(audio, 'init_audio')
 		const { container } = render_scene()
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		scene.click()
@@ -127,6 +135,7 @@ describe('GameScene', () => {
 		const fullscreen_spy = vi.spyOn(fullscreen, 'request').mockResolvedValue()
 		const { container } = render_scene()
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		scene.click()
@@ -139,6 +148,7 @@ describe('GameScene', () => {
 		const audio_spy = vi.spyOn(audio, 'init_audio')
 		const { container } = render_scene()
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		scene.click()
@@ -150,6 +160,7 @@ describe('GameScene', () => {
 		const spy = vi.spyOn(fullscreen_switch_input, 'set_container')
 		const { container } = render_scene()
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		expect(spy).toHaveBeenCalledWith(scene)
 	})
@@ -157,6 +168,7 @@ describe('GameScene', () => {
 	it('sets session.is_session_started to true after first click', () => {
 		const { container } = render_scene()
 		const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 		expect(scene).toBeTruthy()
 		if (!scene) return
 		expect(session.is_session_started).toBe(false)
@@ -166,12 +178,14 @@ describe('GameScene', () => {
 
 	it('does not render cyber-glow when game_state.is_alt is false', () => {
 		const { container } = render_scene()
+
 		expect(container.querySelector('[data-testid="cyber-glow"]')).toBeNull()
 	})
 
 	it('renders cyber-glow when game_state.is_alt is true', () => {
 		game_state.toggle_alt()
 		const { container } = render_scene()
+
 		expect(container.querySelector('[data-testid="cyber-glow"]')).toBeTruthy()
 	})
 
@@ -179,6 +193,7 @@ describe('GameScene', () => {
 		it('pressing ESC while session is active calls reset_session', () => {
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			scene.click()
@@ -190,6 +205,7 @@ describe('GameScene', () => {
 		it('pressing Z while session is active calls reset_session', () => {
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			scene.click()
@@ -201,6 +217,7 @@ describe('GameScene', () => {
 		it('pressing ESC while session is not active does not start the game', () => {
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			expect(session.is_session_started).toBe(false)
@@ -213,6 +230,7 @@ describe('GameScene', () => {
 		it('pressing Enter starts the session', () => {
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			expect(session.is_session_started).toBe(false)
@@ -223,6 +241,7 @@ describe('GameScene', () => {
 		it('pressing Space does NOT start the session (reserved for jump input)', () => {
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			expect(session.is_session_started).toBe(false)
@@ -235,6 +254,7 @@ describe('GameScene', () => {
 		it('joystick zones are rendered before session starts so move/look work in overlay', () => {
 			vi.spyOn(device, 'is_touch_primary', 'get').mockReturnValue(true)
 			const { container } = render_scene()
+
 			expect(container.querySelectorAll('.joystick-zone')).toHaveLength(2)
 		})
 	})
@@ -245,6 +265,7 @@ describe('GameScene', () => {
 			vi.spyOn(fullscreen, 'request').mockResolvedValue()
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			scene.click()
@@ -256,6 +277,7 @@ describe('GameScene', () => {
 			vi.spyOn(device, 'is_touch_primary', 'get').mockReturnValue(false)
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			scene.click()
@@ -266,6 +288,7 @@ describe('GameScene', () => {
 		it('does not show pause button before session starts', () => {
 			vi.spyOn(device, 'is_touch_primary', 'get').mockReturnValue(true)
 			const { container } = render_scene()
+
 			expect(container.querySelector('[data-testid="pause-btn"]')).toBeNull()
 		})
 
@@ -274,11 +297,13 @@ describe('GameScene', () => {
 			vi.spyOn(fullscreen, 'request').mockResolvedValue()
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			scene.click()
 			flushSync()
 			const pause_btn = container.querySelector<HTMLElement>('[data-testid="pause-btn"]')
+
 			expect(pause_btn).toBeTruthy()
 			if (!pause_btn) return
 			pause_btn.click()
@@ -291,14 +316,17 @@ describe('GameScene', () => {
 			vi.spyOn(fullscreen, 'request').mockResolvedValue()
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			if (!scene) return
 			scene.click()
 			flushSync()
 			const pause_btn = container.querySelector<HTMLElement>('[data-testid="pause-btn"]')
+
 			expect(pause_btn).toBeTruthy()
 			if (!pause_btn) return
 			const style = globalThis.getComputedStyle(pause_btn)
+
 			expect(style.bottom).toBe('16px')
 			expect(style.right).toBe('16px')
 		})
@@ -339,24 +367,29 @@ describe('GameScene', () => {
 	describe('CRT filter overlay — scanlines + vignette over the whole game screen', () => {
 		it('renders a CRT overlay element over the game container, regardless of session state', () => {
 			const { container } = render_scene()
+
 			expect(container.querySelector('[data-testid="crt-overlay"]')).toBeTruthy()
 		})
 
 		it('CRT overlay is a sibling of the Canvas so it covers the entire game screen', () => {
 			const { container } = render_scene()
 			const game_scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(game_scene).toBeTruthy()
 			if (!game_scene) return
 			const overlay = game_scene.querySelector<HTMLElement>('[data-testid="crt-overlay"]')
+
 			expect(overlay?.parentElement).toBe(game_scene)
 		})
 
 		it('CRT overlay does not block pointer events (UI underneath stays interactive)', () => {
 			const { container } = render_scene()
 			const overlay = container.querySelector<HTMLElement>('[data-testid="crt-overlay"]')
+
 			expect(overlay).toBeTruthy()
 			if (!overlay) return
 			const style = globalThis.getComputedStyle(overlay)
+
 			expect(style.pointerEvents).toBe('none')
 		})
 
@@ -400,6 +433,7 @@ describe('GameScene', () => {
 			expect(GAME_SCENE_SOURCE).not.toMatch(
 				/\.game-container\.crt-active\s+:global\(canvas\)[\s\S]*?hue-rotate/u,
 			)
+
 			// Negative: previous filter values must not be present on the canvas filter chain.
 			for (const prior of [
 				'contrast\\(1\\.08\\)',
@@ -456,6 +490,7 @@ describe('GameScene', () => {
 					),
 				)
 			}
+
 			// Negative: the prior 0.55 alpha must not be present in any corner-darkening position.
 			expect(GAME_SCENE_SOURCE).not.toMatch(
 				/radial-gradient\(\s*circle\s+at\s+(?:top|bottom)\s+(?:left|right),\s*rgba\(\s*0,\s*0,\s*0,\s*0\.55\s*\)/u,
@@ -528,6 +563,7 @@ describe('GameScene', () => {
 		it('renders the SVG <filter id="crt-chromatic"> into the DOM at mount', () => {
 			const { container } = render_scene()
 			const filter = container.querySelector('#crt-chromatic')
+
 			expect(filter).toBeTruthy()
 			expect(filter?.tagName.toLowerCase()).toBe('filter')
 		})
@@ -548,6 +584,7 @@ describe('GameScene', () => {
 			vi.spyOn(fullscreen, 'is_active', 'get').mockReturnValue(true)
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			expect(scene?.classList.contains('is-fullscreen')).toBe(true)
 		})
@@ -556,6 +593,7 @@ describe('GameScene', () => {
 			vi.spyOn(fullscreen, 'is_active', 'get').mockReturnValue(false)
 			const { container } = render_scene()
 			const scene = container.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 			expect(scene).toBeTruthy()
 			expect(scene?.classList.contains('is-fullscreen')).toBe(false)
 		})
@@ -637,6 +675,7 @@ describe('GameScene', () => {
 		it('keeps [role="status"] visually hidden before the session starts', () => {
 			const { container } = render_scene()
 			const status = container.querySelector<HTMLElement>('[role="status"]')
+
 			expect(status).toBeTruthy()
 			if (!status) return
 			expect(status.getBoundingClientRect().height).toBeLessThanOrEqual(
@@ -646,9 +685,11 @@ describe('GameScene', () => {
 
 		it('keeps [role="status"] visually hidden after session.start_session()', () => {
 			const { container } = render_scene()
+
 			session.start_session()
 			flushSync()
 			const status = container.querySelector<HTMLElement>('[role="status"]')
+
 			expect(status).toBeTruthy()
 			if (!status) return
 			expect(status.textContent).toBe(LABEL_GAME_STARTED)

--- a/src/lib/game-kit/audio.test.ts
+++ b/src/lib/game-kit/audio.test.ts
@@ -7,6 +7,7 @@ afterEach(() => {
 
 function make_audio_ctx_ctor(state: AudioContextState) {
 	const resume = vi.fn().mockImplementation(() => Promise.resolve())
+
 	return {
 		ctor: class {
 			readonly state = state
@@ -27,9 +28,11 @@ describe('game audio', () => {
 	it('get_audio_context resumes suspended AudioContext', async () => {
 		vi.resetModules()
 		const { ctor, resume } = make_audio_ctx_ctor('suspended')
+
 		vi.stubGlobal('AudioContext', ctor)
 
 		const { audio } = await import('./audio')
+
 		audio.init_audio()
 		audio.get_audio_context()
 
@@ -39,9 +42,11 @@ describe('game audio', () => {
 	it('get_audio_context does not call resume when running', async () => {
 		vi.resetModules()
 		const { ctor, resume } = make_audio_ctx_ctor('running')
+
 		vi.stubGlobal('AudioContext', ctor)
 
 		const { audio } = await import('./audio')
+
 		audio.init_audio()
 		audio.get_audio_context()
 
@@ -51,6 +56,7 @@ describe('game audio', () => {
 	it('init_audio is idempotent — multiple calls create only one AudioContext', async () => {
 		vi.resetModules()
 		let instance_count = 0
+
 		vi.stubGlobal(
 			'AudioContext',
 			class {
@@ -62,6 +68,7 @@ describe('game audio', () => {
 		)
 
 		const { audio } = await import('./audio')
+
 		audio.init_audio()
 		audio.init_audio()
 

--- a/src/lib/game-kit/audio.ts
+++ b/src/lib/game-kit/audio.ts
@@ -8,6 +8,7 @@ function init_audio(): void {
 
 function get_audio_context(): AudioContext | null {
 	if (ctx?.state === 'suspended') void ctx.resume().catch(() => {})
+
 	return ctx
 }
 

--- a/src/lib/game-kit/controls/ControlsScene.svelte
+++ b/src/lib/game-kit/controls/ControlsScene.svelte
@@ -168,14 +168,17 @@
 	async function svg_to_texture(svg: string, tex_w: number, tex_h: number): Promise<CanvasTexture> {
 		const blob = new Blob([svg], { type: 'image/svg+xml' })
 		const url = URL.createObjectURL(blob)
+
 		try {
 			const img = new Image()
+
 			img.src = url
 			await new Promise<void>(function wait(resolve, reject): void {
 				img.onload = (): void => resolve()
 				img.onerror = (): void => reject(new Error('svg load failed'))
 			})
 			const canvas = document.createElement('canvas')
+
 			canvas.width = tex_w
 			canvas.height = tex_h
 			const ctx_2d = canvas.getContext('2d')
@@ -183,8 +186,10 @@
 			ctx_2d.clearRect(0, 0, tex_w, tex_h)
 			ctx_2d.drawImage(img, 0, 0, tex_w, tex_h)
 			const tex = new CanvasTexture(canvas)
+
 			tex.minFilter = NearestFilter
 			tex.magFilter = NearestFilter
+
 			return tex
 		} finally {
 			URL.revokeObjectURL(url)
@@ -193,6 +198,7 @@
 
 	onMount(function setup(): () => void {
 		let alive = true
+
 		void (async function load_textures(): Promise<void> {
 			try {
 				const [kb, ms, tc] = await Promise.all([
@@ -200,12 +206,15 @@
 					svg_to_texture(MOUSE_SVG, MOUSE_TEX_W, MOUSE_TEX_H),
 					svg_to_texture(TOUCH_SVG, TOUCH_TEX_W, TOUCH_TEX_H),
 				])
+
 				if (!alive) {
 					kb.dispose()
 					ms.dispose()
 					tc.dispose()
+
 					return
 				}
+
 				keyboard_tex = kb
 				mouse_tex = ms
 				touch_tex = tc
@@ -213,6 +222,7 @@
 				console.warn('[ControlsScene] failed to load control hint textures', error)
 			}
 		})()
+
 		return function cleanup(): void {
 			alive = false
 			keyboard_tex?.dispose()

--- a/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
+++ b/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
@@ -12,6 +12,7 @@ function find_mesh_open_tag(source: string, position_marker: string): string {
 	const block_start = source.lastIndexOf('<T.Mesh', start_index)
 	const block_end = source.indexOf('>', start_index)
 	if (block_start < 0 || block_end < 0) throw new Error(`mesh open tag not bounded`)
+
 	return source.slice(block_start, block_end + 1)
 }
 
@@ -21,6 +22,7 @@ function find_mesh_full_block(source: string, position_marker: string): string {
 	const block_start = source.lastIndexOf('<T.Mesh', start_index)
 	const block_end = source.indexOf('</T.Mesh>', start_index)
 	if (block_start < 0 || block_end < 0) throw new Error(`mesh full block not bounded`)
+
 	return source.slice(block_start, block_end)
 }
 
@@ -30,6 +32,7 @@ function find_mesh_blocks_by_render_order(
 ): Array<string> {
 	const blocks: Array<string> = []
 	let cursor = 0
+
 	while (cursor < source.length) {
 		const order_index = source.indexOf(render_order_token, cursor)
 		if (order_index < 0) break
@@ -39,28 +42,33 @@ function find_mesh_blocks_by_render_order(
 		blocks.push(source.slice(block_start, block_end))
 		cursor = block_end + 1
 	}
+
 	return blocks
 }
 
 describe('ControlsScene render order — regression for camera-angle brightness flicker', () => {
 	it('backdrop mesh declares renderOrder=0 so it draws before foreground icons', () => {
 		const block = find_mesh_open_tag(SOURCE, 'BACKDROP_X, BACKDROP_Y, BACKDROP_Z')
+
 		expect(block).toContain(`renderOrder={BACKDROP_RENDER_ORDER}`)
 		expect(SOURCE).toContain(`const BACKDROP_RENDER_ORDER = ${String(BACKDROP_RENDER_ORDER_VALUE)}`)
 	})
 
 	it('touch icon mesh declares renderOrder=1 so it draws after the backdrop', () => {
 		const block = find_mesh_open_tag(SOURCE, '[0, TOUCH_Y, TOUCH_Z]')
+
 		expect(block).toContain(`renderOrder={FOREGROUND_RENDER_ORDER}`)
 	})
 
 	it('keyboard icon mesh declares renderOrder=1 so it draws after the backdrop', () => {
 		const block = find_mesh_open_tag(SOURCE, '[KEYBOARD_X, 0, 0]')
+
 		expect(block).toContain(`renderOrder={FOREGROUND_RENDER_ORDER}`)
 	})
 
 	it('mouse icon mesh declares renderOrder=1 so it draws after the backdrop', () => {
 		const block = find_mesh_open_tag(SOURCE, '[MOUSE_X, MOUSE_Y, 0]')
+
 		expect(block).toContain(`renderOrder={FOREGROUND_RENDER_ORDER}`)
 	})
 
@@ -75,6 +83,7 @@ describe('ControlsScene render order — regression for camera-angle brightness 
 describe('ControlsScene dual-backdrop — icons dim through backdrop from both sides', () => {
 	it('front-facing backdrop uses FrontSide so it draws only when camera is in front', () => {
 		const blocks = find_mesh_blocks_by_render_order(SOURCE, 'renderOrder={BACKDROP_RENDER_ORDER}')
+
 		expect(blocks).toHaveLength(1)
 		expect(blocks[0]).toContain('side={FrontSide}')
 		expect(blocks[0]).toContain('opacity={BACKDROP_OPACITY}')
@@ -85,6 +94,7 @@ describe('ControlsScene dual-backdrop — icons dim through backdrop from both s
 			SOURCE,
 			'renderOrder={BACKDROP_BACK_RENDER_ORDER}',
 		)
+
 		expect(blocks).toHaveLength(1)
 		expect(blocks[0]).toContain('side={BackSide}')
 		expect(blocks[0]).toContain('opacity={BACKDROP_OPACITY}')
@@ -95,6 +105,7 @@ describe('ControlsScene dual-backdrop — icons dim through backdrop from both s
 			SOURCE,
 			'renderOrder={BACKDROP_BACK_RENDER_ORDER}',
 		)
+
 		expect(blocks[0]).toContain('position={[BACKDROP_X, BACKDROP_Y, BACKDROP_Z]}')
 	})
 
@@ -109,6 +120,7 @@ describe('ControlsScene dual-backdrop — icons dim through backdrop from both s
 		const touch_block = find_mesh_full_block(SOURCE, '[0, TOUCH_Y, TOUCH_Z]')
 		const keyboard_block = find_mesh_full_block(SOURCE, '[KEYBOARD_X, 0, 0]')
 		const mouse_block = find_mesh_full_block(SOURCE, '[MOUSE_X, MOUSE_Y, 0]')
+
 		expect(touch_block).toContain('side={DoubleSide}')
 		expect(keyboard_block).toContain('side={DoubleSide}')
 		expect(mouse_block).toContain('side={DoubleSide}')
@@ -178,8 +190,10 @@ describe('ControlsScene PC icon fit — keyboard and mouse must not overflow the
 describe('ControlsScene keyboard letters — overlaid as Threlte Text using the theme font', () => {
 	it('keyboard SVG contains only key boxes (no <text> elements) — letters are overlaid as Threlte Text', () => {
 		const svg_match = SOURCE.match(/const\s+KEYBOARD_SVG\s*=\s*`([\s\S]*?)`/u)
+
 		expect(svg_match).not.toBeNull()
 		const svg_body = svg_match?.[1] ?? ''
+
 		expect(svg_body).not.toContain('<text')
 		// Hardcoded font-family must not appear anywhere
 		expect(SOURCE).not.toContain('"Orbitron, monospace"')
@@ -188,8 +202,10 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 	it('KEYBOARD_LETTERS array enumerates all 7 letter overlays (W, A, S, D, ESC, /, Z)', () => {
 		expect(SOURCE).toMatch(/const\s+KEYBOARD_LETTERS\s*:\s*ReadonlyArray<KeyboardLetter>\s*=/u)
 		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
+
 		expect(letter_match).not.toBeNull()
 		const block = letter_match?.[0] ?? ''
+
 		expect(block).toContain("text: 'W'")
 		expect(block).toContain("text: 'A'")
 		expect(block).toContain("text: 'S'")
@@ -204,6 +220,7 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 		// silent drift during unrelated edits could shrink the keys back.
 		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		const block = letter_match?.[0] ?? ''
+
 		expect(block).toMatch(/text:\s*'W'[^}]*vsize:\s*16/u)
 		expect(block).toMatch(/text:\s*'A'[^}]*vsize:\s*16/u)
 		expect(block).toMatch(/text:\s*'S'[^}]*vsize:\s*16/u)
@@ -215,6 +232,7 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 		// space-to-ESC gap. The letter vy values must follow the rect centers.
 		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		const block = letter_match?.[0] ?? ''
+
 		expect(block).toMatch(/text:\s*'W'[^}]*vy:\s*38/u)
 		expect(block).toMatch(/text:\s*'A'[^}]*vy:\s*82/u)
 		expect(block).toMatch(/text:\s*'S'[^}]*vy:\s*82/u)
@@ -227,6 +245,7 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 		// literal value prevents accidental regression to the previous tiny size.
 		const letter_match = SOURCE.match(/const\s+KEYBOARD_LETTERS[\s\S]*?\n\t\]/u)
 		const block = letter_match?.[0] ?? ''
+
 		expect(block).toMatch(/text:\s*'ESC'[^}]*vsize:\s*12/u)
 	})
 
@@ -244,8 +263,10 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 
 	it('letter Text uses font={current_font} so it matches the hint text font exactly', () => {
 		const each_block = SOURCE.match(/\{#each\s+KEYBOARD_LETTERS[\s\S]*?\{\/each\}/u)
+
 		expect(each_block).not.toBeNull()
 		const block = each_block?.[0] ?? ''
+
 		expect(block).toContain('font={current_font}')
 		expect(block).toContain('fontSize={viewbox_size_to_world(letter.vsize, current_font_size_mul)}')
 		expect(block).toContain('color={letter.color}')
@@ -292,8 +313,10 @@ describe('ControlsScene viewport reactivity — sizes update on window resize', 
 describe('ControlsScene texture loading — leak-safe blob URLs and unhandled rejections', () => {
 	it('svg_to_texture revokes the object URL in a finally block (no leak on failure)', () => {
 		const fn_match = SOURCE.match(/async\s+function\s+svg_to_texture\([\s\S]*?\n\t\}/u)
+
 		expect(fn_match).not.toBeNull()
 		const body = fn_match?.[0] ?? ''
+
 		expect(body).toMatch(/\}\s*finally\s*\{[\s\S]*URL\.revokeObjectURL\(url\)[\s\S]*\}/u)
 	})
 
@@ -301,13 +324,16 @@ describe('ControlsScene texture loading — leak-safe blob URLs and unhandled re
 		const fn_match = SOURCE.match(/async\s+function\s+svg_to_texture\([\s\S]*?\n\t\}/u)
 		const body = fn_match?.[0] ?? ''
 		const revoke_count = (body.match(/URL\.revokeObjectURL\(/gu) ?? []).length
+
 		expect(revoke_count).toBe(1)
 	})
 
 	it('load_textures catches Promise.all rejection to avoid unhandled rejection', () => {
 		const fn_match = SOURCE.match(/async\s+function\s+load_textures\([\s\S]*?\}\)\(\)/u)
+
 		expect(fn_match).not.toBeNull()
 		const body = fn_match?.[0] ?? ''
+
 		expect(body).toMatch(/try\s*\{[\s\S]*await Promise\.all/u)
 		expect(body).toMatch(/\}\s*catch\s*\([^)]*\)\s*\{/u)
 	})
@@ -317,6 +343,7 @@ function extract_const_number(source: string, name: string): number {
 	const re = new RegExp(`const\\s+${name}\\s*=\\s*(-?\\d+(?:\\.\\d+)?)`, 'u')
 	const match = source.match(re)
 	if (!match) throw new Error(`constant ${name} not found in source`)
+
 	return Number(match[1])
 }
 
@@ -338,6 +365,7 @@ describe('ControlsScene PC icon padding — keyboard left padding equals mouse r
 		const mouse_w = extract_const_number(SOURCE, 'MOUSE_W')
 		const keyboard_left_outer = Math.abs(keyboard_x - keyboard_w / HALF_DIVISOR_VALUE)
 		const mouse_right_outer = mouse_x + mouse_w / HALF_DIVISOR_VALUE
+
 		expect(Math.abs(keyboard_left_outer - mouse_right_outer)).toBeLessThan(
 			PLANE_OUTER_SYMMETRY_TOLERANCE,
 		)
@@ -352,6 +380,7 @@ describe('ControlsScene PC icon padding — keyboard left padding equals mouse r
 		const keyboard_body_left = keyboard_plane_left + KEYBOARD_SVG_LEFT_MARGIN_FRACTION * keyboard_w
 		const mouse_plane_right = mouse_x + mouse_w / HALF_DIVISOR_VALUE
 		const mouse_body_right = mouse_plane_right - MOUSE_SVG_SIDE_MARGIN_FRACTION * mouse_w
+
 		expect(Math.abs(Math.abs(keyboard_body_left) - mouse_body_right)).toBeLessThan(
 			BODY_SYMMETRY_TOLERANCE,
 		)
@@ -359,6 +388,7 @@ describe('ControlsScene PC icon padding — keyboard left padding equals mouse r
 
 	it('PC_GROUP_Y is raised to add bottom padding under the keyboard', () => {
 		const pc_group_y = extract_const_number(SOURCE, 'PC_GROUP_Y')
+
 		expect(pc_group_y).toBe(EXPECTED_PC_GROUP_Y)
 	})
 
@@ -376,6 +406,7 @@ describe('ControlsScene PC icon padding — keyboard left padding equals mouse r
 		const inner_gap = mouse_plane_left - keyboard_plane_right
 		const HALVED_GAP_TARGET = 0.15
 		const GAP_TOLERANCE = 0.02
+
 		expect(Math.abs(inner_gap - HALVED_GAP_TARGET)).toBeLessThan(GAP_TOLERANCE)
 	})
 })
@@ -412,6 +443,7 @@ describe('ControlsScene keyboard row spacing — WASD lowered so ASD↔Space gap
 		const space_bottom = EXPECTED_SPACE_ROW_Y + EXPECTED_SPACE_ROW_HEIGHT
 		const asd_to_space = EXPECTED_SPACE_ROW_Y - asd_bottom
 		const space_to_esc = EXPECTED_ESC_ROW_Y - space_bottom
+
 		expect(asd_to_space).toBe(EXPECTED_ASD_TO_SPACE_GAP)
 		expect(space_to_esc).toBe(EXPECTED_SPACE_TO_ESC_GAP)
 		expect(asd_to_space).toBe(space_to_esc)
@@ -470,12 +502,16 @@ const TOUCH_SVG_GESTURE_GROUP_COUNT = 2
 describe('ControlsScene touch SVG gesture centering — illustration vertically centered within frame', () => {
 	it('both gesture group y-translations center the bounding box within the frame rect', () => {
 		const svg_match = SOURCE.match(/const\s+TOUCH_SVG\s*=\s*`([\s\S]*?)`/u)
+
 		expect(svg_match).not.toBeNull()
 		const svg_body = svg_match?.[1] ?? ''
 		const translate_matches = [...svg_body.matchAll(/transform="translate\(\d+,(-?\d+)\)"/gu)]
+
 		expect(translate_matches).toHaveLength(TOUCH_SVG_GESTURE_GROUP_COUNT)
+
 		for (const match of translate_matches) {
 			const translate_y = Number(match[1])
+
 			expect(Math.abs(translate_y - TOUCH_SVG_CENTERING_TRANSLATE_Y)).toBeLessThanOrEqual(
 				TOUCH_SVG_CENTERING_TOLERANCE,
 			)

--- a/src/lib/game-kit/controls/JumpIcon.svelte.test.ts
+++ b/src/lib/game-kit/controls/JumpIcon.svelte.test.ts
@@ -6,24 +6,28 @@ describe('JumpIcon', () => {
 	it('renders an SVG with viewBox 0 0 40 40 (matches controls-preview Jump C)', () => {
 		const { container } = render(JumpIcon)
 		const svg = container.querySelector('svg')
+
 		expect(svg?.getAttribute('viewBox')).toBe('0 0 40 40')
 	})
 
 	it('renders at text-sized 20x20 dimensions', () => {
 		const { container } = render(JumpIcon)
 		const svg = container.querySelector('svg')
+
 		expect(svg?.getAttribute('width')).toBe('20')
 		expect(svg?.getAttribute('height')).toBe('20')
 	})
 
 	it('has two polyline elements for double chevron', () => {
 		const { container } = render(JumpIcon)
+
 		expect(container.querySelectorAll('polyline')).toHaveLength(2)
 	})
 
 	it('uses original Jump C coordinates (bottom solid, top animated)', () => {
 		const { container } = render(JumpIcon)
 		const polylines = Array.from(container.querySelectorAll('polyline'))
+
 		expect(polylines[0]?.getAttribute('points')).toBe('8,27 20,15 32,27')
 		expect(polylines[1]?.getAttribute('points')).toBe('8,19 20,7 32,19')
 		expect(polylines[1]?.classList.contains('chevron-top')).toBe(true)

--- a/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
@@ -7,12 +7,14 @@ const PROPS = { label_move: 'Move', label_jump: 'Jump', label_return: 'Return' }
 describe('KeyboardDiagram', () => {
 	it('renders the SVG diagram', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
+
 		expect(container.querySelector('svg.keyboard-diagram')).toBeTruthy()
 	})
 
 	it('SVG aria-label includes move, jump, and return labels for screen readers', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const aria = container.querySelector('svg.keyboard-diagram')?.getAttribute('aria-label') ?? ''
+
 		expect(aria).toContain(PROPS.label_move)
 		expect(aria).toContain(PROPS.label_jump)
 		expect(aria).toContain(PROPS.label_return)
@@ -22,6 +24,7 @@ describe('KeyboardDiagram', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const texts = Array.from(container.querySelectorAll('text'))
 		const move_label = texts.find((t) => t.textContent?.trim() === PROPS.label_move)
+
 		expect(move_label).toBeUndefined()
 	})
 
@@ -29,6 +32,7 @@ describe('KeyboardDiagram', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const texts = Array.from(container.querySelectorAll('text'))
 		const esc = texts.find((t) => t.textContent?.trim() === 'ESC')
+
 		expect(esc).toBeTruthy()
 		expect(esc?.getAttribute('dominant-baseline')).toBe('central')
 		expect(esc?.getAttribute('y')).toBe('162')
@@ -37,6 +41,7 @@ describe('KeyboardDiagram', () => {
 	it('places A/S/D keys with same gap as W-to-S gap', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const s_rect = container.querySelector('.key-s rect')
+
 		expect(s_rect?.getAttribute('y')).toBe('46')
 	})
 
@@ -44,15 +49,19 @@ describe('KeyboardDiagram', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const texts = Array.from(container.querySelectorAll('text'))
 		const has_orbitron = texts.every((t) => t.getAttribute('font-family')?.includes('Orbitron'))
+
 		expect(has_orbitron).toBe(true)
 	})
 
 	it('spacebar uses double chevron (two 3-point polylines, no straight line)', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const polylines = Array.from(container.querySelectorAll('.key-space polyline'))
+
 		expect(polylines).toHaveLength(2)
+
 		for (const p of polylines) {
 			const points = p.getAttribute('points')?.trim().split(/\s+/u) ?? []
+
 			expect(points).toHaveLength(3)
 		}
 	})
@@ -69,6 +78,7 @@ describe('KeyboardDiagram', () => {
 					.map((pt) => Number(pt.split(',')[1])) ?? [],
 		)
 		const span = Math.max(...all_y_values) - Math.min(...all_y_values)
+
 		expect(span).toBeLessThanOrEqual(13)
 	})
 })

--- a/src/lib/game-kit/controls/MouseDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/MouseDiagram.svelte.test.ts
@@ -7,6 +7,7 @@ const PROPS = { label_action: 'Action', label_look: 'Look around' }
 describe('MouseDiagram', () => {
 	it('renders the SVG diagram', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
+
 		expect(container.querySelector('svg.mouse-diagram')).toBeTruthy()
 	})
 
@@ -14,6 +15,7 @@ describe('MouseDiagram', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
 		const texts = Array.from(container.querySelectorAll('text'))
 		const action = texts.find((t) => t.textContent?.trim() === PROPS.label_action)
+
 		expect(action).toBeUndefined()
 	})
 
@@ -21,6 +23,7 @@ describe('MouseDiagram', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
 		const texts = Array.from(container.querySelectorAll('text'))
 		const look = texts.find((t) => t.textContent?.trim() === PROPS.label_look)
+
 		expect(look).toBeUndefined()
 	})
 
@@ -30,23 +33,28 @@ describe('MouseDiagram', () => {
 		const wheel = rects.find(
 			(r) => r.getAttribute('rx') === '5' && r.getAttribute('width') === '10',
 		)
+
 		expect(wheel).toBeUndefined()
 	})
 
 	it('does not render drag arrow', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
+
 		expect(container.querySelector('.drag-arrow')).toBeNull()
 	})
 
 	it('uses viewBox "0 -7 90 120" so content is vertically centered', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
+
 		expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe('0 -7 90 120')
 	})
 
 	it('all stroke-widths are <= 1 to match keyboard visual stroke width', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
 		const stroked = Array.from(container.querySelectorAll('[stroke-width]'))
+
 		expect(stroked.length).toBeGreaterThan(0)
+
 		for (const el of stroked) {
 			expect(Number(el.getAttribute('stroke-width'))).toBeLessThanOrEqual(1)
 		}

--- a/src/lib/game-kit/controls/TouchDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/TouchDiagram.svelte.test.ts
@@ -8,6 +8,7 @@ describe('TouchDiagram', () => {
 	it('renders the touch-diagram container with role and aria-label', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
 		const diagram = container.querySelector('.touch-diagram')
+
 		expect(diagram).toBeTruthy()
 		expect(diagram?.getAttribute('role')).toBe('img')
 		expect(diagram?.getAttribute('aria-label')).toContain(PROPS.label_move)
@@ -17,12 +18,14 @@ describe('TouchDiagram', () => {
 
 	it('renders a frame and two halves so width can stretch with viewport', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
+
 		expect(container.querySelector('[data-testid="touch-diagram-frame"]')).toBeTruthy()
 		expect(container.querySelectorAll('.frame .half')).toHaveLength(2)
 	})
 
 	it('renders move-gesture and look-gesture as separate fixed-size SVGs', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
+
 		expect(container.querySelector('svg.move-gesture')).toBeTruthy()
 		expect(container.querySelector('svg.look-gesture')).toBeTruthy()
 	})
@@ -31,6 +34,7 @@ describe('TouchDiagram', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
 		const move = container.querySelector('svg.move-gesture')
 		const look = container.querySelector('svg.look-gesture')
+
 		expect(move?.getAttribute('viewBox')).toBe('27 14 58 54')
 		expect(look?.getAttribute('viewBox')).toBe('27 14 58 54')
 	})
@@ -38,6 +42,7 @@ describe('TouchDiagram', () => {
 	it('does not render any visible label text', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
 		const texts = Array.from(container.querySelectorAll('text'))
+
 		expect(texts).toHaveLength(0)
 	})
 
@@ -45,6 +50,7 @@ describe('TouchDiagram', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
 		const path = container.querySelector('svg.move-gesture path')
 		const ring = container.querySelector('svg.move-gesture circle')
+
 		expect(path?.getAttribute('stroke')).toContain('160,130,255')
 		expect(ring?.getAttribute('stroke')).toContain('160,130,255')
 	})

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte
@@ -37,6 +37,7 @@
 		for (const t of list) {
 			if (t.identifier === id) return t
 		}
+
 		return undefined
 	}
 
@@ -83,6 +84,7 @@
 	function apply_dead_zone(raw: number): number {
 		const abs = Math.abs(raw)
 		if (abs < MOVE_DEAD_ZONE) return 0
+
 		return Math.sign(raw) * clamp((abs - MOVE_DEAD_ZONE) / (MOVE_MAX_DIST - MOVE_DEAD_ZONE), 0, 1)
 	}
 
@@ -90,6 +92,7 @@
 		if (Math.hypot(t.clientX - move_start_x, t.clientY - move_start_y) > TAP_DRAG_THRESHOLD) {
 			move_did_drag = true
 		}
+
 		input.set_joystick_move(
 			apply_dead_zone(t.clientX - move_start_x),
 			apply_dead_zone(move_start_y - t.clientY),
@@ -100,9 +103,11 @@
 		if (Math.hypot(t.clientX - look_start_x, t.clientY - look_start_y) > TAP_DRAG_THRESHOLD) {
 			look_did_drag = true
 		}
+
 		const sensitivity = look_is_first_move
 			? TOUCH_LOOK_SENSITIVITY * FIRST_MOVE_SENSITIVITY_FRACTION
 			: TOUCH_LOOK_SENSITIVITY
+
 		look_is_first_move = false
 		input.apply_look_delta(
 			(t.clientX - look_last_x) * sensitivity,
@@ -117,6 +122,7 @@
 			const t = find_touch(e.changedTouches, move_touch_id)
 			if (t) apply_move_touch(t)
 		}
+
 		if (look_touch_id !== null) {
 			const t = find_touch(e.changedTouches, look_touch_id)
 			if (t) apply_look_touch(t)
@@ -157,6 +163,7 @@
 				move_start_y,
 			)
 		}
+
 		if (id === look_touch_id) {
 			look_touch_id = null
 			joystick_dispatch.dispatch_pointer_cancel(
@@ -191,6 +198,7 @@
 		document.addEventListener('touchmove', on_touch_move, { passive: false })
 		document.addEventListener('touchend', on_touch_end)
 		document.addEventListener('touchcancel', on_touch_cancel)
+
 		return () => {
 			move_zone.removeEventListener('touchstart', on_move_start)
 			look_zone.removeEventListener('touchstart', on_look_start)

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte.test.ts
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte.test.ts
@@ -27,14 +27,17 @@ function fire(type: string, target: EventTarget, changed: Array<Touch>, all: Arr
 function setup_threlte_dom(): { dom: HTMLDivElement; canvas: HTMLCanvasElement } {
 	const dom = document.createElement('div')
 	const canvas = document.createElement('canvas')
+
 	dom.appendChild(canvas)
 	document.body.appendChild(dom)
+
 	return { dom, canvas }
 }
 
 describe('VirtualJoystick', () => {
 	it('renders jump button inside overlay but not inside any joystick zone', () => {
 		const { container } = render_joystick()
+
 		expect(container.querySelector('.joystick-overlay [data-testid="jump-btn"]')).toBeTruthy()
 		expect(container.querySelector('.joystick-zone [data-testid="jump-btn"]')).toBeNull()
 	})
@@ -42,6 +45,7 @@ describe('VirtualJoystick', () => {
 	it('jump button has aria-label and svg icon instead of visible text', () => {
 		const { container } = render_joystick()
 		const btn = container.querySelector<HTMLElement>('[data-testid="jump-btn"]')
+
 		expect(btn?.getAttribute('aria-label')).toBe(LABEL_JUMP)
 		expect(btn?.querySelector('svg')).toBeTruthy()
 		expect(btn?.textContent?.trim()).toBe('')
@@ -50,6 +54,7 @@ describe('VirtualJoystick', () => {
 	it('joystick-zone does not capture pointer events on non-touch devices', () => {
 		const { container } = render_joystick()
 		const zone = container.querySelector<HTMLElement>('.joystick-zone')
+
 		expect(zone).toBeTruthy()
 		if (!zone) return
 		expect(getComputedStyle(zone).pointerEvents).toBe('none')
@@ -58,6 +63,7 @@ describe('VirtualJoystick', () => {
 	it('overlay has touch-action none to allow simultaneous two-finger input', () => {
 		const { container } = render_joystick()
 		const overlay = container.querySelector<HTMLElement>('.joystick-overlay')
+
 		expect(overlay).toBeTruthy()
 		if (!overlay) return
 		expect(getComputedStyle(overlay).touchAction).toBe('none')
@@ -67,6 +73,7 @@ describe('VirtualJoystick', () => {
 		const { container } = render(VirtualJoystick, {
 			props: { label_jump: LABEL_JUMP, show_jump: false },
 		})
+
 		expect(container.querySelector('[data-testid="jump-btn"]')).toBeNull()
 	})
 
@@ -74,15 +81,18 @@ describe('VirtualJoystick', () => {
 		const { container } = render(VirtualJoystick, {
 			props: { label_jump: LABEL_JUMP, show_jump: false },
 		})
+
 		expect(container.querySelectorAll('.joystick-zone')).toHaveLength(2)
 	})
 
 	it('jump button is positioned near the bottom-right corner', () => {
 		const { container } = render_joystick()
 		const overlay = container.querySelector<HTMLElement>('.joystick-overlay')
+
 		expect(overlay).toBeTruthy()
 		if (!overlay) return
 		const styles = getComputedStyle(overlay)
+
 		expect(styles.getPropertyValue('--jump-btn-bottom').trim()).toBe('12%')
 		expect(styles.getPropertyValue('--jump-btn-left').trim()).toBe('82%')
 	})
@@ -90,9 +100,11 @@ describe('VirtualJoystick', () => {
 	it('jump button matches pause button styling (size, background, border, color)', () => {
 		const { container } = render_joystick()
 		const btn = container.querySelector<HTMLElement>('[data-testid="jump-btn"]')
+
 		expect(btn).toBeTruthy()
 		if (!btn) return
 		const style = getComputedStyle(btn)
+
 		expect(style.width).toBe('44px')
 		expect(style.height).toBe('44px')
 		expect(style.backgroundColor).toBe('rgba(255, 255, 255, 0.15)')
@@ -115,14 +127,17 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'set_joystick_move')
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t_start = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t_start], [t_start])
 
 		const MOVE_MAX_DIST = 40
 		const t_move = make_touch(1, 100 + MOVE_MAX_DIST, 200, move_zone)
+
 		fire('touchmove', document, [t_move], [t_move])
 
 		expect(spy).toHaveBeenCalledWith(1, 0)
@@ -132,14 +147,17 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'set_joystick_move')
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t_start = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t_start], [t_start])
 
 		const MOVE_DEAD_ZONE = 6
 		const t_move = make_touch(1, 100 + MOVE_DEAD_ZONE - 1, 200, move_zone)
+
 		fire('touchmove', document, [t_move], [t_move])
 
 		expect(spy).toHaveBeenCalledWith(0, 0)
@@ -149,14 +167,17 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'set_joystick_move')
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t_start = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t_start], [t_start])
 
 		const MOVE_DEAD_ZONE = 6
 		const t_move = make_touch(1, 100 + MOVE_DEAD_ZONE, 200, move_zone)
+
 		fire('touchmove', document, [t_move], [t_move])
 
 		expect(spy).toHaveBeenCalledWith(0, 0)
@@ -166,19 +187,23 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'set_joystick_move')
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t_start = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t_start], [t_start])
 
 		const MOVE_MAX_DIST = 40
 		const MOVE_DEAD_ZONE = 6
 		const mid = MOVE_DEAD_ZONE + (MOVE_MAX_DIST - MOVE_DEAD_ZONE) / 2
 		const t_move = make_touch(1, 100 + mid, 200, move_zone)
+
 		fire('touchmove', document, [t_move], [t_move])
 
 		const [dx] = spy.mock.calls.at(-1) ?? [0, 0]
+
 		expect(dx).toBeCloseTo(0.5)
 	})
 
@@ -186,19 +211,23 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'apply_look_delta')
 		const { container } = render_joystick()
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
+
 		expect(look_zone).toBeTruthy()
 		if (!look_zone) return
 
 		const t_start = make_touch(2, 300, 200, look_zone)
+
 		fire('touchstart', look_zone, [t_start], [t_start])
 
 		const t_first = make_touch(2, 310, 190, look_zone)
+
 		fire('touchmove', document, [t_first], [t_first])
 
 		expect(spy).toHaveBeenCalledOnce()
 		const [delta_yaw, delta_pitch] = spy.mock.calls[0] ?? [0, 0]
 		const TOUCH_LOOK_SENSITIVITY = 0.009
 		const FIRST_MOVE_SENSITIVITY_FRACTION = 0.2
+
 		expect(delta_yaw).toBeCloseTo(10 * TOUCH_LOOK_SENSITIVITY * FIRST_MOVE_SENSITIVITY_FRACTION)
 		expect(delta_pitch).toBeCloseTo(-10 * TOUCH_LOOK_SENSITIVITY * FIRST_MOVE_SENSITIVITY_FRACTION)
 	})
@@ -207,21 +236,26 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'apply_look_delta')
 		const { container } = render_joystick()
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
+
 		expect(look_zone).toBeTruthy()
 		if (!look_zone) return
 
 		const t_start = make_touch(2, 300, 200, look_zone)
+
 		fire('touchstart', look_zone, [t_start], [t_start])
 
 		const t_first = make_touch(2, 310, 195, look_zone)
+
 		fire('touchmove', document, [t_first], [t_first])
 
 		const t_second = make_touch(2, 320, 185, look_zone)
+
 		fire('touchmove', document, [t_second], [t_second])
 
 		expect(spy).toHaveBeenCalledTimes(2)
 		const [delta_yaw, delta_pitch] = spy.mock.calls[1] ?? [0, 0]
 		const TOUCH_LOOK_SENSITIVITY = 0.009
+
 		expect(delta_yaw).toBeCloseTo(10 * TOUCH_LOOK_SENSITIVITY)
 		expect(delta_pitch).toBeCloseTo(-10 * TOUCH_LOOK_SENSITIVITY)
 	})
@@ -233,17 +267,21 @@ describe('VirtualJoystick touch handlers', () => {
 		const zones = container.querySelectorAll('.joystick-zone')
 		const move_zone = zones.item(0)
 		const look_zone = zones.item(1)
+
 		expect(move_zone).toBeTruthy()
 		expect(look_zone).toBeTruthy()
 		if (!move_zone || !look_zone) return
 
 		const t1 = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t1], [t1])
 		const t2 = make_touch(2, 300, 200, look_zone)
+
 		fire('touchstart', look_zone, [t2], [t2])
 
 		const t1m = make_touch(1, 120, 200, move_zone)
 		const t2m = make_touch(2, 310, 190, look_zone)
+
 		fire('touchmove', document, [t1m, t2m], [t1m, t2m])
 
 		expect(move_spy).toHaveBeenCalled()
@@ -254,10 +292,12 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'set_joystick_move')
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 		fire('touchend', document, [t], [])
 
@@ -267,18 +307,22 @@ describe('VirtualJoystick touch handlers', () => {
 	it('touching move zone dispatches pointerdown to threlte dom (canvas parent)', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('pointerdown', spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 
 		expect(spy).toHaveBeenCalledOnce()
 		const pointer_event = spy.mock.calls[0]?.[0] as PointerEvent
+
 		expect(pointer_event.pointerId).toBe(1)
 		expect(pointer_event.offsetX).toBe(100)
 		expect(pointer_event.offsetY).toBe(200)
@@ -288,18 +332,23 @@ describe('VirtualJoystick touch handlers', () => {
 	it('drag on move zone (touchmove > threshold) does NOT dispatch click on touchend', () => {
 		const { dom } = setup_threlte_dom()
 		const click_spy = vi.fn()
+
 		dom.addEventListener('click', click_spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t_start = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t_start], [t_start])
 		const t_drag = make_touch(1, 130, 230, move_zone)
+
 		fire('touchmove', document, [t_drag], [t_drag])
 		const t_end = make_touch(1, 130, 230, move_zone)
+
 		fire('touchend', document, [t_end], [])
 
 		expect(click_spy).not.toHaveBeenCalled()
@@ -309,18 +358,23 @@ describe('VirtualJoystick touch handlers', () => {
 	it('drag on look zone (touchmove > threshold) does NOT dispatch click on touchend', () => {
 		const { dom } = setup_threlte_dom()
 		const click_spy = vi.fn()
+
 		dom.addEventListener('click', click_spy)
 
 		const { container } = render_joystick()
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
+
 		expect(look_zone).toBeTruthy()
 		if (!look_zone) return
 
 		const t_start = make_touch(2, 300, 200, look_zone)
+
 		fire('touchstart', look_zone, [t_start], [t_start])
 		const t_drag = make_touch(2, 330, 230, look_zone)
+
 		fire('touchmove', document, [t_drag], [t_drag])
 		const t_end = make_touch(2, 330, 230, look_zone)
+
 		fire('touchend', document, [t_end], [])
 
 		expect(click_spy).not.toHaveBeenCalled()
@@ -330,20 +384,25 @@ describe('VirtualJoystick touch handlers', () => {
 	it('releasing move zone dispatches click to threlte dom at start position', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('click', spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 150, 250, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 		const t_end = make_touch(1, 200, 300, move_zone)
+
 		fire('touchend', document, [t_end], [])
 
 		expect(spy).toHaveBeenCalledOnce()
 		const click_event = spy.mock.calls[0]?.[0] as MouseEvent
+
 		expect(click_event.clientX).toBe(150)
 		expect(click_event.clientY).toBe(250)
 		expect(click_event.offsetX).toBe(150)
@@ -354,14 +413,17 @@ describe('VirtualJoystick touch handlers', () => {
 	it('releasing move zone dispatches pointerleave to threlte dom', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('pointerleave', spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 		fire('touchend', document, [t], [])
 
@@ -372,18 +434,22 @@ describe('VirtualJoystick touch handlers', () => {
 	it('touching look zone dispatches pointerdown to threlte dom', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('pointerdown', spy)
 
 		const { container } = render_joystick()
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
+
 		expect(look_zone).toBeTruthy()
 		if (!look_zone) return
 
 		const t = make_touch(2, 300, 200, look_zone)
+
 		fire('touchstart', look_zone, [t], [t])
 
 		expect(spy).toHaveBeenCalledOnce()
 		const pointer_event = spy.mock.calls[0]?.[0] as PointerEvent
+
 		expect(pointer_event.pointerId).toBe(2)
 		expect(pointer_event.offsetX).toBe(300)
 		expect(pointer_event.offsetY).toBe(200)
@@ -393,14 +459,17 @@ describe('VirtualJoystick touch handlers', () => {
 	it('touchcancel does not dispatch click to threlte dom', () => {
 		const { dom } = setup_threlte_dom()
 		const click_spy = vi.fn()
+
 		dom.addEventListener('click', click_spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 		fire('touchcancel', document, [t], [])
 
@@ -411,14 +480,17 @@ describe('VirtualJoystick touch handlers', () => {
 	it('touchcancel dispatches pointerup to threlte dom', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('pointerup', spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 		fire('touchcancel', document, [t], [])
 
@@ -429,14 +501,17 @@ describe('VirtualJoystick touch handlers', () => {
 	it('touchcancel dispatches pointerleave to threlte dom', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('pointerleave', spy)
 
 		const { container } = render_joystick()
 		const move_zone = container.querySelector('.joystick-zone')
+
 		expect(move_zone).toBeTruthy()
 		if (!move_zone) return
 
 		const t = make_touch(1, 100, 200, move_zone)
+
 		fire('touchstart', move_zone, [t], [t])
 		fire('touchcancel', document, [t], [])
 
@@ -447,14 +522,17 @@ describe('VirtualJoystick touch handlers', () => {
 	it('tapping jump button does not dispatch to threlte dom', () => {
 		const { dom } = setup_threlte_dom()
 		const spy = vi.fn()
+
 		dom.addEventListener('pointerdown', spy)
 
 		const { container } = render_joystick()
 		const jump_btn = container.querySelector<HTMLButtonElement>('[data-testid="jump-btn"]')
+
 		expect(jump_btn).toBeTruthy()
 		if (!jump_btn) return
 
 		const t = make_touch(2, 300, 200, jump_btn)
+
 		fire('touchstart', jump_btn, [t], [t])
 
 		expect(spy).not.toHaveBeenCalled()
@@ -465,10 +543,12 @@ describe('VirtualJoystick touch handlers', () => {
 		const spy = vi.spyOn(input, 'trigger_jump')
 		const { container } = render_joystick()
 		const jump_btn = container.querySelector<HTMLButtonElement>('[data-testid="jump-btn"]')
+
 		expect(jump_btn).toBeTruthy()
 		if (!jump_btn) return
 
 		const t = make_touch(3, 300, 400, jump_btn)
+
 		fire('touchstart', jump_btn, [t], [t])
 
 		expect(spy).toHaveBeenCalledOnce()
@@ -479,14 +559,17 @@ describe('VirtualJoystick touch handlers', () => {
 		const { container } = render_joystick()
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
 		const jump_btn = container.querySelector<HTMLButtonElement>('[data-testid="jump-btn"]')
+
 		expect(look_zone).toBeTruthy()
 		expect(jump_btn).toBeTruthy()
 		if (!look_zone || !jump_btn) return
 
 		const look_touch = make_touch(1, 300, 200, look_zone)
+
 		fire('touchstart', look_zone, [look_touch], [look_touch])
 
 		const jump_touch = make_touch(2, 300, 400, jump_btn)
+
 		fire('touchstart', jump_btn, [jump_touch], [look_touch, jump_touch])
 
 		expect(spy).toHaveBeenCalledOnce()

--- a/src/lib/game-kit/controls/controls-fit.test.ts
+++ b/src/lib/game-kit/controls/controls-fit.test.ts
@@ -8,11 +8,13 @@ const SIDES = 2
 describe('compute_fit_scale', () => {
 	it('returns 1 when natural span plus required padding fits in view width', () => {
 		const wide_view_width = NATURAL_SPAN + SIDES * MIN_PADDING + 10
+
 		expect(compute_fit_scale(wide_view_width, NATURAL_SPAN, MIN_PADDING)).toBe(1)
 	})
 
 	it('returns 1 exactly when view_width equals natural_span plus required padding', () => {
 		const exact_view = NATURAL_SPAN + SIDES * MIN_PADDING
+
 		expect(compute_fit_scale(exact_view, NATURAL_SPAN, MIN_PADDING)).toBeCloseTo(1, 10)
 	})
 
@@ -20,21 +22,25 @@ describe('compute_fit_scale', () => {
 		const constrained_view = NATURAL_SPAN
 		const scale = compute_fit_scale(constrained_view, NATURAL_SPAN, MIN_PADDING)
 		const resulting_side_padding = (constrained_view - NATURAL_SPAN * scale) / SIDES
+
 		expect(resulting_side_padding).toBeCloseTo(MIN_PADDING, 10)
 	})
 
 	it('returns 0 when view_width equals 2 × min_side_padding (no room for icons)', () => {
 		const tight_view = SIDES * MIN_PADDING
+
 		expect(compute_fit_scale(tight_view, NATURAL_SPAN, MIN_PADDING)).toBe(0)
 	})
 
 	it('returns 0 when view_width is less than 2 × min_side_padding', () => {
 		const too_tight = SIDES * MIN_PADDING - 0.1
+
 		expect(compute_fit_scale(too_tight, NATURAL_SPAN, MIN_PADDING)).toBe(0)
 	})
 
 	it('returns 1 when natural span is 0 (degenerate input) to avoid division by zero', () => {
 		const any_view_width = 5
+
 		expect(compute_fit_scale(any_view_width, 0, MIN_PADDING)).toBe(1)
 	})
 
@@ -44,15 +50,18 @@ describe('compute_fit_scale', () => {
 
 	it('treats min_side_padding=0 as the no-padding case (icons can occupy full width)', () => {
 		const exact_view = NATURAL_SPAN
+
 		expect(compute_fit_scale(exact_view, NATURAL_SPAN, 0)).toBeCloseTo(1, 10)
 	})
 
 	it('always returns a scale where side padding is >= min_side_padding', () => {
 		const view_widths_under_test = [1, 1.5, 2, 2.5, 3, 4, 10]
+
 		for (const view_width of view_widths_under_test) {
 			const scale = compute_fit_scale(view_width, NATURAL_SPAN, MIN_PADDING)
 			const resulting_side_padding = (view_width - NATURAL_SPAN * scale) / SIDES
 			const headroom = resulting_side_padding - MIN_PADDING
+
 			expect(headroom).toBeGreaterThanOrEqual(-1e-10)
 		}
 	})

--- a/src/lib/game-kit/controls/controls-fit.ts
+++ b/src/lib/game-kit/controls/controls-fit.ts
@@ -11,6 +11,7 @@ function compute_fit_scale(
 	const available_width = view_width - SIDES * min_side_padding
 	if (available_width <= 0) return MIN_SCALE
 	const fit_scale = available_width / natural_span
+
 	return Math.min(MAX_SCALE, fit_scale)
 }
 

--- a/src/lib/game-kit/crt-barrel.test.ts
+++ b/src/lib/game-kit/crt-barrel.test.ts
@@ -15,6 +15,7 @@ const WIDE_ASPECT = 16 / 9
 function distance_from_center(x: number, y: number): number {
 	const dx = x - CENTER_X
 	const dy = y - CENTER_Y
+
 	return Math.sqrt(dx * dx + dy * dy)
 }
 
@@ -43,6 +44,7 @@ describe('crt_barrel.apply_barrel_uv', () => {
 		for (const strength of [0, 0.1, BARREL_STRENGTH, 0.5]) {
 			for (const aspect of [SQUARE_ASPECT, WIDE_ASPECT, 9 / 16]) {
 				const out = crt_barrel.apply_barrel_uv({ x: CENTER_X, y: CENTER_Y }, strength, aspect)
+
 				expect(out.x).toBeCloseTo(CENTER_X, 10)
 				expect(out.y).toBeCloseTo(CENTER_Y, 10)
 			}
@@ -56,8 +58,10 @@ describe('crt_barrel.apply_barrel_uv', () => {
 			{ x: 0.25, y: 0.75 },
 			{ x: 0.1, y: 0.9 },
 		]
+
 		for (const uv of samples) {
 			const out = crt_barrel.apply_barrel_uv(uv, 0, SQUARE_ASPECT)
+
 			expect(out.x).toBeCloseTo(uv.x, 10)
 			expect(out.y).toBeCloseTo(uv.y, 10)
 		}
@@ -72,10 +76,12 @@ describe('crt_barrel.apply_barrel_uv', () => {
 			{ x: 0.2, y: 0.2 },
 			{ x: 0.8, y: 0.8 },
 		]
+
 		for (const uv of off_center_samples) {
 			const before = distance_from_center(uv.x, uv.y)
 			const after_uv = crt_barrel.apply_barrel_uv(uv, BARREL_STRENGTH, SQUARE_ASPECT)
 			const after = distance_from_center(after_uv.x, after_uv.y)
+
 			expect(after).toBeGreaterThan(before)
 		}
 	})
@@ -86,6 +92,7 @@ describe('crt_barrel.apply_barrel_uv', () => {
 			{ x: 0.1, y: 0.4 },
 			{ x: 0.25, y: 0.6 },
 		]
+
 		for (const uv of samples) {
 			const forward = crt_barrel.apply_barrel_uv(uv, BARREL_STRENGTH, SQUARE_ASPECT)
 			const opposite = crt_barrel.apply_barrel_uv(
@@ -93,6 +100,7 @@ describe('crt_barrel.apply_barrel_uv', () => {
 				BARREL_STRENGTH,
 				SQUARE_ASPECT,
 			)
+
 			expect(opposite.x).toBeCloseTo(1 - forward.x, 10)
 			expect(opposite.y).toBeCloseTo(1 - forward.y, 10)
 		}
@@ -106,6 +114,7 @@ describe('crt_barrel.apply_barrel_uv', () => {
 			{ x: 0.8, y: 0.1 },
 			{ x: 0.6, y: 0.9 },
 		]
+
 		for (const uv of samples) {
 			const out = crt_barrel.apply_barrel_uv(uv, BARREL_STRENGTH, SQUARE_ASPECT)
 			const in_dx = uv.x - CENTER_X
@@ -113,6 +122,7 @@ describe('crt_barrel.apply_barrel_uv', () => {
 			const out_dx = out.x - CENTER_X
 			const out_dy = out.y - CENTER_Y
 			const cross = in_dx * out_dy - in_dy * out_dx
+
 			expect(Math.abs(cross)).toBeLessThan(1e-10)
 		}
 	})
@@ -125,6 +135,7 @@ describe('crt_barrel.apply_barrel_uv', () => {
 		const wide_out = crt_barrel.apply_barrel_uv(corner, BARREL_STRENGTH, WIDE_ASPECT)
 		const square_dx = Math.abs(square_out.x - corner.x)
 		const wide_dx = Math.abs(wide_out.x - corner.x)
+
 		expect(wide_dx).toBeGreaterThan(square_dx)
 	})
 })

--- a/src/lib/game-kit/crt-barrel.ts
+++ b/src/lib/game-kit/crt-barrel.ts
@@ -25,6 +25,7 @@ function apply_barrel_uv(uv: BarrelUv, strength: number, aspect: number): Barrel
 	const warp = 1 + strength * r2
 	const warped_x = (centered_x * warp) / aspect
 	const warped_y = centered_y * warp
+
 	return { x: warped_x + HALF, y: warped_y + HALF }
 }
 

--- a/src/lib/game-kit/crt-dither.test.ts
+++ b/src/lib/game-kit/crt-dither.test.ts
@@ -29,6 +29,7 @@ describe('crt-dither constants', () => {
 
 	it('exposes COLOR_LEVELS = { r: 8, g: 8, b: 4 } (8×8×4 = 256 unique colors, VGA 3-3-2)', () => {
 		const VGA_332_TOTAL_COLORS = 256
+
 		expect(COLOR_LEVELS).toEqual({ r: 8, g: 8, b: 4 })
 		expect(COLOR_LEVELS.r * COLOR_LEVELS.g * COLOR_LEVELS.b).toBe(VGA_332_TOTAL_COLORS)
 	})
@@ -104,6 +105,7 @@ describe('crt_dither.compute_scanline_factor (cosine profile)', () => {
 	it('returns a smooth intermediate value at phase = period/4 (no hard step)', () => {
 		// Hard-step would return SCANLINE_DARK here; cosine (sharpness=1) returns mid-value.
 		const mid = SCANLINE_DARK + 0.5 * (1 - SCANLINE_DARK)
+
 		expect(
 			crt_dither.compute_scanline_factor(QUARTER_PERIOD, PERIOD, SCANLINE_DARK, 1),
 		).toBeCloseTo(mid, 6)
@@ -117,6 +119,7 @@ describe('crt_dither.compute_scanline_factor (cosine profile)', () => {
 			SCANLINE_DARK,
 			SCANLINE_SHARPNESS,
 		)
+
 		expect(sharpness_thin).toBeGreaterThan(sharpness_1)
 	})
 
@@ -132,6 +135,7 @@ describe('crt_dither.compute_scanline_factor (cosine profile)', () => {
 	it('always stays within [SCANLINE_DARK, 1.0] for all phases', () => {
 		for (let t = 0; t <= PERIOD; t += PERIOD / 20) {
 			const v = crt_dither.compute_scanline_factor(t, PERIOD, SCANLINE_DARK)
+
 			expect(v).toBeGreaterThanOrEqual(SCANLINE_DARK - 1e-10)
 			expect(v).toBeLessThanOrEqual(1 + 1e-10)
 		}
@@ -140,6 +144,7 @@ describe('crt_dither.compute_scanline_factor (cosine profile)', () => {
 	it('repeats every period units', () => {
 		for (let i = 0; i < 5; i++) {
 			const base = i * PERIOD
+
 			expect(crt_dither.compute_scanline_factor(base, PERIOD, SCANLINE_DARK)).toBeCloseTo(
 				SCANLINE_DARK,
 				10,
@@ -164,6 +169,7 @@ describe('crt_dither.compute_scanline_factor (cosine profile)', () => {
 describe('BAYER_MATRIX', () => {
 	it(`is a ${BAYER_SIZE}×${BAYER_SIZE} matrix`, () => {
 		expect(BAYER_MATRIX).toHaveLength(BAYER_SIZE)
+
 		for (const row of BAYER_MATRIX) {
 			expect(row).toHaveLength(BAYER_SIZE)
 		}
@@ -171,6 +177,7 @@ describe('BAYER_MATRIX', () => {
 
 	it(`contains every integer 0..${MAX_BAYER_VALUE} exactly once (proper Bayer ordering)`, () => {
 		const seen = new Set<number>()
+
 		for (const row of BAYER_MATRIX) {
 			for (const value of row) {
 				expect(Number.isInteger(value)).toBe(true)
@@ -179,6 +186,7 @@ describe('BAYER_MATRIX', () => {
 				seen.add(value)
 			}
 		}
+
 		expect(seen.size).toBe(SQUARED_BAYER_SIZE)
 	})
 })
@@ -194,6 +202,7 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 			for (let bi = 0; bi < SQUARED_BAYER_SIZE; bi++) {
 				const bayer = bi / SQUARED_BAYER_SIZE
 				const out = crt_dither.quantize_with_dither_2d(VERY_DARK, bayer, levels, BLACK_FLOOR)
+
 				expect(out).toBeGreaterThanOrEqual(BLACK_FLOOR)
 			}
 		}
@@ -204,6 +213,7 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 			for (let bi = 0; bi < SQUARED_BAYER_SIZE; bi++) {
 				const bayer = bi / SQUARED_BAYER_SIZE
 				const out = crt_dither.quantize_with_dither_2d(1, bayer, levels, BLACK_FLOOR)
+
 				expect(out).toBeLessThanOrEqual(1)
 			}
 		}
@@ -218,15 +228,18 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 			COLOR_LEVELS.r,
 			BLACK_FLOOR,
 		)
+
 		expect(low).not.toBe(high)
 	})
 
 	it('lands on one of N quantization steps for bright inputs (above the black floor)', () => {
 		const BRIGHT_INPUT = 0.7
+
 		for (const levels of [COLOR_LEVELS.r, COLOR_LEVELS.g, COLOR_LEVELS.b]) {
 			const out = crt_dither.quantize_with_dither_2d(BRIGHT_INPUT, BAYER_HIGH, levels, BLACK_FLOOR)
 			const step = 1 / (levels - 1)
 			const nearest_step = Math.round(out / step) * step
+
 			expect(Math.abs(out - nearest_step)).toBeLessThan(1e-6)
 		}
 	})
@@ -237,16 +250,21 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 		// fails this guard at the COLOR_LEVELS change point.
 		function distinct_outputs(levels: number): number {
 			const seen = new Set<number>()
+
 			for (let v = 0; v <= 100; v++) {
 				const channel = v / 100
 				const out = crt_dither.quantize_with_dither_2d(channel, BAYER_HIGH, levels, BLACK_FLOOR)
+
 				seen.add(Math.round(out * 1000))
 			}
+
 			return seen.size
 		}
+
 		const red = distinct_outputs(COLOR_LEVELS.r)
 		const green = distinct_outputs(COLOR_LEVELS.g)
 		const blue = distinct_outputs(COLOR_LEVELS.b)
+
 		expect(green).toBe(red)
 		expect(blue).toBeLessThan(red)
 	})
@@ -255,9 +273,11 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 describe('crt_dither.create_bayer_texture', () => {
 	it(`returns a DataTexture sized ${BAYER_SIZE}×${BAYER_SIZE} with non-zero data`, () => {
 		const tex = crt_dither.create_bayer_texture()
+
 		expect(tex.image.width).toBe(BAYER_SIZE)
 		expect(tex.image.height).toBe(BAYER_SIZE)
 		const data = tex.image.data as Float32Array
+
 		expect(data).toHaveLength(SQUARED_BAYER_SIZE)
 		expect(data.some((value) => value > 0)).toBe(true)
 		tex.dispose()
@@ -266,9 +286,11 @@ describe('crt_dither.create_bayer_texture', () => {
 	it(`stores normalized values in [0, 1) matching BAYER_MATRIX / ${SQUARED_BAYER_SIZE}`, () => {
 		const tex = crt_dither.create_bayer_texture()
 		const data = tex.image.data as Float32Array
+
 		BAYER_MATRIX.forEach((row, y) => {
 			row.forEach((source, x) => {
 				const expected = source / SQUARED_BAYER_SIZE
+
 				expect(data[y * BAYER_SIZE + x]).toBeCloseTo(expected, 6)
 			})
 		})
@@ -307,6 +329,7 @@ describe('DITHER shader sources', () => {
 		const fragment = DITHER_FRAGMENT_SHADER
 		const dither_offset_index = fragment.indexOf('vec3(threshold) * dither_step')
 		const quantize_index = fragment.indexOf('floor(color * u_color_levels)')
+
 		expect(dither_offset_index).toBeGreaterThan(-1)
 		expect(quantize_index).toBeGreaterThan(-1)
 		expect(dither_offset_index).toBeLessThan(quantize_index)
@@ -335,6 +358,7 @@ describe('UPSCALE shader source', () => {
 	it('samples all 4 axis-aligned neighbours for the dot-blend', () => {
 		// 1 center + 4 neighbours = at least 5 texture2D calls
 		const sample_count = (UPSCALE_FRAGMENT_SHADER.match(/texture2D\(\s*u_lo_tex/gu) ?? []).length
+
 		expect(sample_count).toBeGreaterThanOrEqual(5)
 	})
 
@@ -377,6 +401,7 @@ describe('SCANLINE shader source', () => {
 		expect(SCANLINE_FRAGMENT_SHADER).toContain('u_bleed')
 		// Two neighbor samples offset along the scanline axis
 		const samples = (SCANLINE_FRAGMENT_SHADER.match(/texture2D\(\s*tDiffuse/gu) ?? []).length
+
 		expect(samples).toBeGreaterThanOrEqual(3)
 		// Bleed attenuates with (1 - wave) so dark bands get max glow, bright bands get none
 		expect(SCANLINE_FRAGMENT_SHADER).toMatch(/\(\s*1\.0\s*-\s*wave\s*\)/u)
@@ -397,6 +422,7 @@ describe('ShaderPass uniform binding (CrtDitherPass regression)', () => {
 	function get_uniform_vec2(pass: ShaderPass): Vector2 {
 		const slot = pass.uniforms['u_res']
 		if (!slot) throw new Error('u_res uniform missing on pass')
+
 		return slot.value as Vector2
 	}
 
@@ -407,12 +433,15 @@ describe('ShaderPass uniform binding (CrtDitherPass regression)', () => {
 			vertexShader: TRIVIAL_VERTEX_SHADER,
 			fragmentShader: TRIVIAL_FRAGMENT_SHADER,
 		})
+
 		expect(pass.uniforms['u_res']).not.toBe(local.u_res)
 		expect(get_uniform_vec2(pass)).not.toBe(local.u_res.value)
 		const NEW_WIDTH = 320
 		const NEW_HEIGHT = 240
+
 		local.u_res.value.set(NEW_WIDTH, NEW_HEIGHT)
 		const cloned = get_uniform_vec2(pass)
+
 		expect(cloned.x).toBe(1)
 		expect(cloned.y).toBe(1)
 	})
@@ -425,12 +454,15 @@ describe('ShaderPass uniform binding (CrtDitherPass regression)', () => {
 			fragmentShader: TRIVIAL_FRAGMENT_SHADER,
 		})
 		const pass = new ShaderPass(material)
+
 		expect(pass.uniforms['u_res']).toBe(local.u_res)
 		expect(get_uniform_vec2(pass)).toBe(local.u_res.value)
 		const NEW_WIDTH = 320
 		const NEW_HEIGHT = 240
+
 		local.u_res.value.set(NEW_WIDTH, NEW_HEIGHT)
 		const live = get_uniform_vec2(pass)
+
 		expect(live.x).toBe(NEW_WIDTH)
 		expect(live.y).toBe(NEW_HEIGHT)
 	})

--- a/src/lib/game-kit/crt-dither.ts
+++ b/src/lib/game-kit/crt-dither.ts
@@ -67,17 +67,20 @@ export const BAYER_MATRIX: ReadonlyArray<ReadonlyArray<number>> = [
 function create_bayer_texture(): DataTexture {
 	const cells = BAYER_SIZE_VALUE * BAYER_SIZE_VALUE
 	const data = new Float32Array(cells)
+
 	BAYER_MATRIX.forEach((row, y) => {
 		row.forEach((value, x) => {
 			data[y * BAYER_SIZE_VALUE + x] = value / cells
 		})
 	})
 	const texture = new DataTexture(data, BAYER_SIZE_VALUE, BAYER_SIZE_VALUE, RedFormat, FloatType)
+
 	texture.minFilter = NearestFilter
 	texture.magFilter = NearestFilter
 	texture.wrapS = RepeatWrapping
 	texture.wrapT = RepeatWrapping
 	texture.needsUpdate = true
+
 	return texture
 }
 
@@ -99,6 +102,7 @@ function compute_scanline_factor(
 	const phase = ((coord % period) + period) % period
 	const wave_cos = HALF * (1 - Math.cos((TWO_PI * phase) / period))
 	const wave = Math.pow(wave_cos, sharpness)
+
 	return dark_factor + wave * (1 - dark_factor)
 }
 
@@ -116,6 +120,7 @@ function quantize_with_dither_2d(
 	const dithered = channel + threshold * dither_step
 	const quantized = Math.floor(dithered * levels) / (levels - 1)
 	const clamped = Math.min(1, Math.max(0, quantized))
+
 	return Math.max(clamped, floor_val)
 }
 

--- a/src/lib/game-kit/crt.svelte.test.ts
+++ b/src/lib/game-kit/crt.svelte.test.ts
@@ -35,6 +35,7 @@ describe('create_crt isolation', () => {
 	it('two instances do not share is_crt_enabled state', () => {
 		const a = create_crt()
 		const b = create_crt()
+
 		a.toggle()
 		expect(a.is_crt_enabled).toBe(false)
 		expect(b.is_crt_enabled).toBe(true)

--- a/src/lib/game-kit/device.svelte.ts
+++ b/src/lib/game-kit/device.svelte.ts
@@ -3,9 +3,11 @@ const TOUCH_PRIMARY_QUERY = '(hover: none) and (pointer: coarse)'
 export function create_device() {
 	const mql = globalThis.matchMedia?.(TOUCH_PRIMARY_QUERY) ?? null
 	let is_touch = $state(mql?.matches ?? false)
+
 	mql?.addEventListener('change', (e: MediaQueryListEvent) => {
 		is_touch = e.matches
 	})
+
 	return {
 		get is_touch_primary(): boolean {
 			return is_touch

--- a/src/lib/game-kit/device.test.ts
+++ b/src/lib/game-kit/device.test.ts
@@ -7,6 +7,7 @@ type ChangeListener = (e: { matches: boolean }) => void
 
 function make_mock_mql(initial: boolean): MediaQueryList & { _fire: (v: boolean) => void } {
 	const listeners: Array<ChangeListener> = []
+
 	return {
 		matches: initial,
 		addEventListener(_: string, fn: EventListenerOrEventListenerObject): void {
@@ -27,19 +28,23 @@ describe('device', () => {
 	it('is_touch_primary is true when media query matches', () => {
 		vi.stubGlobal('matchMedia', () => make_mock_mql(true))
 		const d = create_device()
+
 		expect(d.is_touch_primary).toBe(true)
 	})
 
 	it('is_touch_primary is false when media query does not match', () => {
 		vi.stubGlobal('matchMedia', () => make_mock_mql(false))
 		const d = create_device()
+
 		expect(d.is_touch_primary).toBe(false)
 	})
 
 	it('uses the touch primary media query', () => {
 		let received = ''
+
 		vi.stubGlobal('matchMedia', (q: string) => {
 			received = q
+
 			return make_mock_mql(false)
 		})
 		create_device()
@@ -48,8 +53,10 @@ describe('device', () => {
 
 	it('updates is_touch_primary when media query changes to true', () => {
 		const mql = make_mock_mql(false)
+
 		vi.stubGlobal('matchMedia', () => mql)
 		const d = create_device()
+
 		expect(d.is_touch_primary).toBe(false)
 		mql._fire(true)
 		expect(d.is_touch_primary).toBe(true)
@@ -57,8 +64,10 @@ describe('device', () => {
 
 	it('updates is_touch_primary when media query changes to false', () => {
 		const mql = make_mock_mql(true)
+
 		vi.stubGlobal('matchMedia', () => mql)
 		const d = create_device()
+
 		expect(d.is_touch_primary).toBe(true)
 		mql._fire(false)
 		expect(d.is_touch_primary).toBe(false)
@@ -67,6 +76,7 @@ describe('device', () => {
 	it('defaults to false when matchMedia is unavailable', () => {
 		vi.stubGlobal('matchMedia', undefined)
 		const d = create_device()
+
 		expect(d.is_touch_primary).toBe(false)
 	})
 })

--- a/src/lib/game-kit/display/FpsDisplay.svelte
+++ b/src/lib/game-kit/display/FpsDisplay.svelte
@@ -12,11 +12,14 @@
 		if (!fps.is_fps_enabled) {
 			frame_count = 0
 			last_time = performance.now()
+
 			return
 		}
+
 		frame_count++
 		const now = performance.now()
 		const elapsed = now - last_time
+
 		if (elapsed >= FPS_UPDATE_INTERVAL_MS) {
 			fps.set_fps_text(String(Math.round((frame_count * MS_PER_SECOND) / elapsed)))
 			frame_count = 0

--- a/src/lib/game-kit/display/ScoreDisplay.svelte
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte
@@ -58,6 +58,7 @@
 	function apply_anim(from: number, to: number, start_ms: number, now: number): number {
 		if (from === to) return to
 		const t = Math.min(1, (now - start_ms) / ANIM_DURATION_MS)
+
 		return Math.round(from + (to - from) * t)
 	}
 
@@ -72,6 +73,7 @@
 				score_from = displayed_score
 				score_anim_ms = now
 			}
+
 			score_to = score_data.current_score
 		}
 

--- a/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
@@ -33,6 +33,7 @@ describe('ScoreDisplay', () => {
 		const { container } = render(ScoreDisplay, {
 			props: { score_data: make_score_data(), is_alt: false, position_z: -4.65, ...LABEL_PROPS },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -40,6 +41,7 @@ describe('ScoreDisplay', () => {
 		const { container } = render(ScoreDisplay, {
 			props: { score_data: make_score_data(), is_alt: true, position_z: -4.65, ...LABEL_PROPS },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -60,6 +62,7 @@ describe('ScoreDisplay', () => {
 				...LABEL_PROPS,
 			},
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -73,6 +76,7 @@ describe('ScoreDisplay', () => {
 				...LABEL_PROPS,
 			},
 		})
+
 		expect(container).toBeTruthy()
 	})
 })

--- a/src/lib/game-kit/display/fps.svelte.test.ts
+++ b/src/lib/game-kit/display/fps.svelte.test.ts
@@ -56,6 +56,7 @@ describe('create_fps isolation', () => {
 	it('two instances do not share is_fps_enabled state', () => {
 		const a = create_fps()
 		const b = create_fps()
+
 		a.toggle()
 		expect(a.is_fps_enabled).toBe(false)
 		expect(b.is_fps_enabled).toBe(true)
@@ -64,6 +65,7 @@ describe('create_fps isolation', () => {
 	it('two instances do not share current_fps_text state', () => {
 		const a = create_fps()
 		const b = create_fps()
+
 		a.set_fps_text('30')
 		expect(a.current_fps_text).toBe('30')
 		expect(b.current_fps_text).toBe('---')

--- a/src/lib/game-kit/display/score-display-color.ts
+++ b/src/lib/game-kit/display/score-display-color.ts
@@ -6,6 +6,7 @@ import {
 
 function get_hi_value_color(is_alt: boolean, is_new_high_score: boolean): string {
 	if (!is_new_high_score) return HI_BASE_COLOR
+
 	return is_alt ? CYBER_NEW_HIGH_COLOR : RETRO_NEW_HIGH_COLOR
 }
 

--- a/src/lib/game-kit/display/score-display-config.test.ts
+++ b/src/lib/game-kit/display/score-display-config.test.ts
@@ -83,6 +83,7 @@ describe('layout geometry', () => {
 		const tilted_half_height = (PANEL_H / HALF_DIVISOR) * Math.cos(PANEL_TILT_X)
 		const scoreboard_bottom_y = DISPLAY_Y - tilted_half_height
 		const edge_gap = scoreboard_bottom_y - board_top_y
+
 		expect(edge_gap).toBeGreaterThan(0)
 		expect(Math.abs(edge_gap - EXPECTED_EDGE_GAP)).toBeLessThan(EDGE_GAP_TOLERANCE)
 	})
@@ -232,6 +233,7 @@ describe('ANIM_DURATION_MS', () => {
 	it('ends at the victory flash finale start (count-up stops when the 4 lamps light up)', () => {
 		const burst_total = FLASH_BURST_CYCLES * (FLASH_BURST_ON_MS + FLASH_BURST_OFF_MS)
 		const cascade_total = BUTTON_COUNT * (FLASH_CASCADE_FWD_MS + FLASH_CASCADE_REV_MS)
+
 		expect(ANIM_DURATION_MS).toBe(burst_total + cascade_total)
 	})
 })

--- a/src/lib/game-kit/fonts.test.ts
+++ b/src/lib/game-kit/fonts.test.ts
@@ -92,8 +92,10 @@ describe('fonts CRT-aware helpers — driven by crt.is_crt_enabled, not by calle
 
 	it('get_active_font tracks CRT state across toggles (no stale capture)', () => {
 		const initial = fonts.get_active_font()
+
 		crt.toggle()
 		const toggled = fonts.get_active_font()
+
 		expect(toggled).not.toBe(initial)
 	})
 })

--- a/src/lib/game-kit/fullscreen.svelte.test.ts
+++ b/src/lib/game-kit/fullscreen.svelte.test.ts
@@ -25,6 +25,7 @@ describe('fullscreen', () => {
 
 	it('uses native requestFullscreen when available', async () => {
 		const spy = vi.spyOn(el, 'requestFullscreen').mockResolvedValue()
+
 		await fullscreen.request(el)
 		expect(spy).toHaveBeenCalledTimes(1)
 		expect(fullscreen.is_pseudo_fullscreen).toBe(false)
@@ -51,6 +52,7 @@ describe('fullscreen', () => {
 		expect(fullscreen.is_pseudo_fullscreen).toBe(true)
 
 		const spy = vi.fn().mockResolvedValue(undefined)
+
 		Object.defineProperty(el, 'requestFullscreen', { value: spy, configurable: true })
 		await fullscreen.request(el)
 		expect(spy).not.toHaveBeenCalled()
@@ -73,10 +75,12 @@ describe('fullscreen', () => {
 			Document.prototype,
 			'fullscreenElement',
 		)
+
 		Object.defineProperty(document, 'fullscreenElement', {
 			get: () => fake_element,
 			configurable: true,
 		})
+
 		try {
 			cleanup = fullscreen.setup_listeners()
 			expect(fullscreen.is_native_fullscreen).toBe(true)
@@ -92,6 +96,7 @@ describe('fullscreen', () => {
 	it('falls back to webkitRequestFullscreen when standard API is missing', async () => {
 		Object.defineProperty(el, 'requestFullscreen', { value: undefined, configurable: true })
 		const webkit_spy = vi.fn().mockResolvedValue(undefined)
+
 		Object.defineProperty(el, 'webkitRequestFullscreen', {
 			value: webkit_spy,
 			configurable: true,
@@ -107,6 +112,7 @@ describe('create_fullscreen isolation', () => {
 		const a = create_fullscreen()
 		const b = create_fullscreen()
 		const el = document.createElement('div')
+
 		Object.defineProperty(el, 'requestFullscreen', { value: undefined, configurable: true })
 		Object.defineProperty(el, 'webkitRequestFullscreen', { value: undefined, configurable: true })
 		await a.request(el)

--- a/src/lib/game-kit/fullscreen.svelte.ts
+++ b/src/lib/game-kit/fullscreen.svelte.ts
@@ -4,6 +4,7 @@ declare global {
 	interface Element {
 		webkitRequestFullscreen?: () => Promise<void> | void
 	}
+
 	interface Document {
 		webkitFullscreenElement?: Element | null
 		webkitExitFullscreen?: () => Promise<void> | void
@@ -19,8 +20,10 @@ function get_native_fullscreen_element(): Element | null {
 async function call_native_request(el: HTMLElement): Promise<boolean> {
 	const fn = el.requestFullscreen ?? el.webkitRequestFullscreen
 	if (typeof fn !== 'function') return false
+
 	try {
 		await fn.call(el)
+
 		return true
 	} catch {
 		return false
@@ -30,6 +33,7 @@ async function call_native_request(el: HTMLElement): Promise<boolean> {
 async function call_native_exit(): Promise<void> {
 	const fn = document.exitFullscreen ?? document.webkitExitFullscreen
 	if (typeof fn !== 'function') return
+
 	try {
 		await fn.call(document)
 	} catch {
@@ -51,8 +55,10 @@ async function request_fullscreen(s: FullscreenState, el: HTMLElement): Promise<
 async function exit_fullscreen(s: FullscreenState): Promise<void> {
 	if (s.is_pseudo_fullscreen) {
 		s.is_pseudo_fullscreen = false
+
 		return
 	}
+
 	if (s.is_native_fullscreen) await call_native_exit()
 }
 
@@ -60,17 +66,21 @@ export function create_fullscreen() {
 	const s = $state<FullscreenState>({ is_pseudo_fullscreen: false, is_native_fullscreen: false })
 	const handler = (): void => update_native_flag(s)
 	let manager: ListenerManager | null = null
+
 	function setup_listeners(): () => void {
 		const m = (manager ??= create_listener_manager([
 			{ target: document, type: 'fullscreenchange', handler },
 			{ target: document, type: 'webkitfullscreenchange', handler },
 		]))
+
 		update_native_flag(s)
+
 		return m.setup((): void => {
 			s.is_native_fullscreen = false
 			s.is_pseudo_fullscreen = false
 		})
 	}
+
 	return {
 		get is_pseudo_fullscreen() {
 			return s.is_pseudo_fullscreen

--- a/src/lib/game-kit/input/input.svelte.test.ts
+++ b/src/lib/game-kit/input/input.svelte.test.ts
@@ -10,13 +10,16 @@ function dispatch_mouse(type: string, init: MouseEventInit): void {
 
 function dispatch_mouse_with_target(type: string, init: MouseEventInit, target: HTMLElement): void {
 	const evt = new MouseEvent(type, init)
+
 	Object.defineProperty(evt, 'target', { value: target })
 	document.dispatchEvent(evt)
 }
 
 function dispatch_wheel(init: WheelEventInit): WheelEvent {
 	const evt = new WheelEvent('wheel', { ...init, cancelable: true })
+
 	document.dispatchEvent(evt)
+
 	return evt
 }
 
@@ -30,6 +33,7 @@ function end_right_drag(): void {
 
 function make_zero_rect_target(): HTMLElement {
 	const target = document.createElement('div')
+
 	document.body.appendChild(target)
 	target.getBoundingClientRect = (): DOMRect =>
 		({
@@ -43,6 +47,7 @@ function make_zero_rect_target(): HTMLElement {
 			y: 0,
 			toJSON: () => ({}),
 		}) as DOMRect
+
 	return target
 }
 
@@ -52,9 +57,11 @@ function make_pointer_event_with_offsets(
 	offset_y: number,
 ): PointerEvent {
 	const evt = new PointerEvent('pointerdown', { button: 0, bubbles: true })
+
 	Object.defineProperty(evt, 'target', { value: target })
 	Object.defineProperty(evt, 'offsetX', { value: offset_x, configurable: true })
 	Object.defineProperty(evt, 'offsetY', { value: offset_y, configurable: true })
+
 	return evt
 }
 
@@ -142,10 +149,12 @@ describe('input', () => {
 
 	it('during drag, capture-phase pointerdown overrides offsetX/Y to drag-start coords', () => {
 		const target = make_zero_rect_target()
+
 		dispatch_mouse('mousedown', { button: RIGHT_BUTTON, clientX: 200, clientY: 150 })
 		expect(input.is_dragging_look).toBe(true)
 
 		const evt = make_pointer_event_with_offsets(target, 999, 999)
+
 		target.dispatchEvent(evt)
 
 		expect(evt.offsetX).toBe(200)
@@ -156,6 +165,7 @@ describe('input', () => {
 	it('without drag, capture-phase listener leaves offsetX/Y untouched', () => {
 		const target = make_zero_rect_target()
 		const evt = make_pointer_event_with_offsets(target, 999, 999)
+
 		target.dispatchEvent(evt)
 
 		expect(evt.offsetX).toBe(999)
@@ -165,6 +175,7 @@ describe('input', () => {
 
 	it('synthesizes pointerdown on canvas when left mousedown fires during drag', () => {
 		const received: Array<string> = []
+
 		canvas_el.addEventListener('pointerdown', (e: PointerEvent) =>
 			received.push(`${e.type}:${e.button}`),
 		)
@@ -176,6 +187,7 @@ describe('input', () => {
 
 	it('synthesizes pointerup on canvas when left mouseup fires during drag', () => {
 		const received: Array<string> = []
+
 		canvas_el.addEventListener('pointerup', (e: PointerEvent) =>
 			received.push(`${e.type}:${e.button}`),
 		)
@@ -187,6 +199,7 @@ describe('input', () => {
 
 	it('does not synthesize pointer events when not dragging', () => {
 		const received: Array<string> = []
+
 		canvas_el.addEventListener('pointerdown', (e: PointerEvent) =>
 			received.push(`${e.type}:${e.button}`),
 		)
@@ -197,19 +210,23 @@ describe('input', () => {
 
 	it('does not synthesize pointer events for right mousedown during drag', () => {
 		const received: Array<string> = []
+
 		canvas_el.addEventListener('pointerdown', (e: PointerEvent) =>
 			received.push(`${e.type}:${e.button}`),
 		)
 		dispatch_mouse('mousedown', { button: RIGHT_BUTTON, clientX: 200, clientY: 150 })
 		const start_count = received.length
+
 		dispatch_mouse('mousedown', { button: RIGHT_BUTTON })
 		expect(received.length).toBe(start_count)
 	})
 
 	it('right mouse down requests pointer lock on event target', () => {
 		const target = document.createElement('div')
+
 		document.body.appendChild(target)
 		const spy = vi.spyOn(target, 'requestPointerLock').mockResolvedValue()
+
 		dispatch_mouse_with_target('mousedown', { button: RIGHT_BUTTON }, target)
 		expect(spy).toHaveBeenCalledTimes(1)
 		target.remove()
@@ -218,6 +235,7 @@ describe('input', () => {
 	it('right mouse up exits pointer lock when locked', () => {
 		vi.spyOn(Document.prototype, 'pointerLockElement', 'get').mockReturnValue(document.body)
 		const spy = vi.spyOn(Document.prototype, 'exitPointerLock').mockImplementation(() => {})
+
 		dispatch_mouse('mouseup', { button: RIGHT_BUTTON })
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
@@ -225,6 +243,7 @@ describe('input', () => {
 	it('right mouse up does not call exitPointerLock when not locked', () => {
 		vi.spyOn(Document.prototype, 'pointerLockElement', 'get').mockReturnValue(null)
 		const spy = vi.spyOn(Document.prototype, 'exitPointerLock').mockImplementation(() => {})
+
 		dispatch_mouse('mouseup', { button: RIGHT_BUTTON })
 		expect(spy).not.toHaveBeenCalled()
 	})
@@ -267,11 +286,13 @@ describe('input', () => {
 
 	it('wheel event preventDefault is called', () => {
 		const evt = dispatch_wheel({ deltaX: 10, deltaY: 0 })
+
 		expect(evt.defaultPrevented).toBe(true)
 	})
 
 	it('contextmenu preventDefault is called', () => {
 		const evt = new MouseEvent('contextmenu', { cancelable: true })
+
 		document.dispatchEvent(evt)
 		expect(evt.defaultPrevented).toBe(true)
 	})
@@ -358,6 +379,7 @@ describe('input', () => {
 
 	it('prevents default on arrow keys to stop page scroll', () => {
 		const evt = new KeyboardEvent('keydown', { key: 'ArrowUp', cancelable: true })
+
 		document.dispatchEvent(evt)
 		expect(evt.defaultPrevented).toBe(true)
 		expect(input.keys.w).toBe(true)
@@ -365,6 +387,7 @@ describe('input', () => {
 
 	it('does not prevent default on letter keys', () => {
 		const evt = new KeyboardEvent('keydown', { key: 'w', cancelable: true })
+
 		document.dispatchEvent(evt)
 		expect(evt.defaultPrevented).toBe(false)
 	})
@@ -378,6 +401,7 @@ describe('input', () => {
 
 	it('setup_listeners is idempotent when called twice', () => {
 		const second_cleanup = input.setup_listeners(canvas_el)
+
 		expect(second_cleanup).toBe(cleanup)
 	})
 
@@ -436,6 +460,7 @@ describe('create_input isolation', () => {
 	it('two instances do not share yaw state', () => {
 		const a = create_input()
 		const b = create_input()
+
 		a.apply_look_delta(-0.5, 0)
 		expect(a.yaw).toBe(0.5)
 		expect(b.yaw).toBe(0)
@@ -446,6 +471,7 @@ describe('create_input isolation', () => {
 		const b = create_input()
 		const cleanup_a = a.setup_listeners(null)
 		const cleanup_b = b.setup_listeners(null)
+
 		cleanup_a()
 		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'w' }))
 		expect(a.keys.w).toBe(false)

--- a/src/lib/game-kit/input/input.svelte.ts
+++ b/src/lib/game-kit/input/input.svelte.ts
@@ -68,6 +68,7 @@ function dispatch_synthetic_pointer(
 		bubbles: true,
 		cancelable: true,
 	})
+
 	canvas_el.dispatchEvent(synth)
 }
 
@@ -105,6 +106,7 @@ function override_offset_during_drag_impl(s: InputState, event: Event): void {
 	if (!s.is_dragging_look) return
 	if (!(event.target instanceof HTMLElement)) return
 	const rect = event.target.getBoundingClientRect()
+
 	override_event_offset(event, s.drag_start_x - rect.left, s.drag_start_y - rect.top)
 }
 
@@ -119,12 +121,16 @@ function on_left_mouse_for_synth_impl(s: InputState, e: MouseEvent, refs: InputR
 function on_key_impl(s: InputState, e: KeyboardEvent, is_down: boolean): void {
 	if (e.key === 'Shift') {
 		s.is_sprinting = is_down
+
 		return
 	}
+
 	if (is_down && e.key === ' ') {
 		s.is_jump_requested = true
+
 		return
 	}
+
 	const key = KEY_MAP[e.key]
 	if (!key) return
 	s.keys[key] = is_down
@@ -133,6 +139,7 @@ function on_key_impl(s: InputState, e: KeyboardEvent, is_down: boolean): void {
 
 function make_drag_override_specs(s: InputState): Array<ListenerSpec> {
 	const handler = (e: Event): void => override_offset_during_drag_impl(s, e)
+
 	return [
 		{ target: document, type: 'pointerdown', handler, options: CAPTURE },
 		{ target: document, type: 'pointerup', handler, options: CAPTURE },
@@ -181,6 +188,7 @@ function make_listener_specs(s: InputState, refs: InputRefs): ReadonlyArray<List
 
 function make_input_api(s: InputState, jm: Vec2, jl: Vec2, refs: InputRefs) {
 	let manager: ListenerManager | null = null
+
 	function on_cleanup(): void {
 		s.yaw = 0
 		s.pitch = 0
@@ -190,6 +198,7 @@ function make_input_api(s: InputState, jm: Vec2, jl: Vec2, refs: InputRefs) {
 		jl.x = 0
 		jl.y = 0
 	}
+
 	return {
 		get is_dragging_look() {
 			return s.is_dragging_look
@@ -224,6 +233,7 @@ function make_input_api(s: InputState, jm: Vec2, jl: Vec2, refs: InputRefs) {
 		setup_listeners: (canvas_el: HTMLCanvasElement | null): (() => void) => {
 			const m = (manager ??= create_listener_manager(make_listener_specs(s, refs)))
 			if (!m.is_active || canvas_el !== null) refs.canvas_el = canvas_el
+
 			return m.setup(on_cleanup)
 		},
 		set_joystick_move: (x: number, y: number): void => {
@@ -264,6 +274,7 @@ export function create_input() {
 	const joystick_move = $state<Vec2>({ x: 0, y: 0 })
 	const joystick_look = $state<Vec2>({ x: 0, y: 0 })
 	const refs: InputRefs = { canvas_el: null }
+
 	return make_input_api(s, joystick_move, joystick_look, refs)
 }
 

--- a/src/lib/game-kit/input/joystick-dispatch.test.ts
+++ b/src/lib/game-kit/input/joystick-dispatch.test.ts
@@ -23,14 +23,17 @@ function make_fake_dom(): { dom: HTMLElement; dispatched: Array<string> } {
 		getBoundingClientRect: () => ({ left: RECT_LEFT, top: RECT_TOP }),
 		dispatchEvent: (e: FakeEvent) => {
 			dispatched.push(e.type)
+
 			return true
 		},
 	} as unknown as HTMLElement
+
 	return { dom, dispatched }
 }
 
 function stub_document(parent: HTMLElement | null): void {
 	const canvas = parent ? { parentElement: parent } : null
+
 	vi.stubGlobal('document', { querySelector: () => canvas })
 }
 
@@ -42,6 +45,7 @@ describe('dispatch_pointer_down', () => {
 	it('does nothing when no canvas found', () => {
 		stub_document(null)
 		const { dispatched } = make_fake_dom()
+
 		joystick_dispatch.dispatch_pointer_down(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y)
 		expect(dispatched).toHaveLength(0)
 	})
@@ -49,6 +53,7 @@ describe('dispatch_pointer_down', () => {
 	it('dispatches pointermove then pointerdown', () => {
 		vi.stubGlobal('PointerEvent', FakeEvent)
 		const { dom, dispatched } = make_fake_dom()
+
 		stub_document(dom)
 		joystick_dispatch.dispatch_pointer_down(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y)
 		expect(dispatched).toEqual(['pointermove', 'pointerdown'])
@@ -59,6 +64,7 @@ describe('dispatch_pointer_up', () => {
 	it('does nothing when no canvas found', () => {
 		stub_document(null)
 		const { dispatched } = make_fake_dom()
+
 		joystick_dispatch.dispatch_pointer_up(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y)
 		expect(dispatched).toHaveLength(0)
 	})
@@ -67,6 +73,7 @@ describe('dispatch_pointer_up', () => {
 		vi.stubGlobal('PointerEvent', FakeEvent)
 		vi.stubGlobal('MouseEvent', FakeEvent)
 		const { dom, dispatched } = make_fake_dom()
+
 		stub_document(dom)
 		joystick_dispatch.dispatch_pointer_up(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y)
 		expect(dispatched).toEqual(['pointerup', 'click', 'pointerleave'])
@@ -76,6 +83,7 @@ describe('dispatch_pointer_up', () => {
 		vi.stubGlobal('PointerEvent', FakeEvent)
 		vi.stubGlobal('MouseEvent', FakeEvent)
 		const { dom, dispatched } = make_fake_dom()
+
 		stub_document(dom)
 		joystick_dispatch.dispatch_pointer_up(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y, false)
 		expect(dispatched).toEqual(['pointerup', 'pointerleave'])
@@ -86,6 +94,7 @@ describe('dispatch_pointer_cancel', () => {
 	it('does nothing when no canvas found', () => {
 		stub_document(null)
 		const { dispatched } = make_fake_dom()
+
 		joystick_dispatch.dispatch_pointer_cancel(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y)
 		expect(dispatched).toHaveLength(0)
 	})
@@ -93,6 +102,7 @@ describe('dispatch_pointer_cancel', () => {
 	it('dispatches pointerup then pointerleave', () => {
 		vi.stubGlobal('PointerEvent', FakeEvent)
 		const { dom, dispatched } = make_fake_dom()
+
 		stub_document(dom)
 		joystick_dispatch.dispatch_pointer_cancel(POINTER_ID, IS_PRIMARY, CLIENT_X, CLIENT_Y)
 		expect(dispatched).toEqual(['pointerup', 'pointerleave'])

--- a/src/lib/game-kit/input/joystick-dispatch.ts
+++ b/src/lib/game-kit/input/joystick-dispatch.ts
@@ -6,6 +6,7 @@ function get_dispatch_ctx(x: number, y: number): DispatchCtx | null {
 	const dom = document.querySelector('canvas')?.parentElement
 	if (!dom) return null
 	const { left, top } = dom.getBoundingClientRect()
+
 	return { dom, offset_x: x - left, offset_y: y - top }
 }
 
@@ -36,9 +37,11 @@ function dispatch_pointer_down(
 	const ctx = get_dispatch_ctx(x, y)
 	if (!ctx) return
 	const opts = build_event_opts(pointer_id, is_primary, x, y)
+
 	opts.buttons = 1
 	const move_ev = new PointerEvent('pointermove', opts)
 	const down_ev = new PointerEvent('pointerdown', opts)
+
 	override_event_offset(move_ev, ctx.offset_x, ctx.offset_y)
 	override_event_offset(down_ev, ctx.offset_x, ctx.offset_y)
 	ctx.dom.dispatchEvent(move_ev)
@@ -57,14 +60,18 @@ function dispatch_pointer_up(
 	const opts = build_event_opts(pointer_id, is_primary, x, y)
 	const up_ev = new PointerEvent('pointerup', opts)
 	const leave_ev = new PointerEvent('pointerleave', opts)
+
 	override_event_offset(up_ev, ctx.offset_x, ctx.offset_y)
 	override_event_offset(leave_ev, ctx.offset_x, ctx.offset_y)
 	ctx.dom.dispatchEvent(up_ev)
+
 	if (is_tap) {
 		const click_ev = new MouseEvent('click', opts)
+
 		override_event_offset(click_ev, ctx.offset_x, ctx.offset_y)
 		ctx.dom.dispatchEvent(click_ev)
 	}
+
 	ctx.dom.dispatchEvent(leave_ev)
 }
 
@@ -79,6 +86,7 @@ function dispatch_pointer_cancel(
 	const opts = build_event_opts(pointer_id, is_primary, x, y)
 	const up_ev = new PointerEvent('pointerup', opts)
 	const leave_ev = new PointerEvent('pointerleave', opts)
+
 	override_event_offset(up_ev, ctx.offset_x, ctx.offset_y)
 	override_event_offset(leave_ev, ctx.offset_x, ctx.offset_y)
 	ctx.dom.dispatchEvent(up_ev)

--- a/src/lib/game-kit/input/override-event-offset.test.ts
+++ b/src/lib/game-kit/input/override-event-offset.test.ts
@@ -7,6 +7,7 @@ const OFFSET_Y = 99
 describe('override_event_offset', () => {
 	it('sets offsetX and offsetY on a plain event', () => {
 		const event = new Event('pointermove')
+
 		override_event_offset(event, OFFSET_X, OFFSET_Y)
 		expect((event as unknown as { offsetX: number }).offsetX).toBe(OFFSET_X)
 		expect((event as unknown as { offsetY: number }).offsetY).toBe(OFFSET_Y)
@@ -14,6 +15,7 @@ describe('override_event_offset', () => {
 
 	it('overwrites a previously set offsetX value', () => {
 		const event = new Event('pointermove')
+
 		override_event_offset(event, OFFSET_X, OFFSET_Y)
 		override_event_offset(event, 0, 0)
 		expect((event as unknown as { offsetX: number }).offsetX).toBe(0)
@@ -22,6 +24,7 @@ describe('override_event_offset', () => {
 
 	it('does not throw when the property is non-configurable', () => {
 		const event = new Event('pointermove')
+
 		Object.defineProperty(event, 'offsetX', { value: 0, configurable: false })
 		expect(() => override_event_offset(event, OFFSET_X, OFFSET_Y)).not.toThrow()
 	})

--- a/src/lib/game-kit/input/pointer-compute.svelte.test.ts
+++ b/src/lib/game-kit/input/pointer-compute.svelte.test.ts
@@ -5,7 +5,9 @@ import { make_pointer_compute } from './pointer-compute.js'
 function make_ctx() {
 	const v = new Vector2()
 	const raycaster = new Raycaster()
+
 	vi.spyOn(raycaster, 'setFromCamera')
+
 	return {
 		pointer: {
 			current: v,
@@ -28,6 +30,7 @@ function make_target(
 	rect_top: number = 0,
 ): HTMLElement {
 	const el = document.createElement('div')
+
 	Object.defineProperty(el, 'clientWidth', { get: () => client_w })
 	Object.defineProperty(el, 'clientHeight', { get: () => client_h })
 	el.getBoundingClientRect = (): DOMRect =>
@@ -42,6 +45,7 @@ function make_target(
 			y: rect_top,
 			toJSON: () => ({}),
 		}) as DOMRect
+
 	return el
 }
 
@@ -89,6 +93,7 @@ describe('make_pointer_compute', () => {
 		const camera = make_camera()
 		const compute = make_pointer_compute(camera)
 		const ctx = make_ctx()
+
 		ctx.pointer.current.set(0.5, 0.5)
 
 		compute(make_event(SKIP_X, SKIP_Y, make_target(0, 0)), ctx)
@@ -102,6 +107,7 @@ describe('make_pointer_compute', () => {
 		const camera = make_camera()
 		const compute = make_pointer_compute(camera)
 		const ctx = make_ctx()
+
 		ctx.pointer.current.set(0.5, 0.5)
 
 		compute(make_event(SKIP_X, SKIP_Y, null), ctx)

--- a/src/lib/game-kit/input/pointer-compute.ts
+++ b/src/lib/game-kit/input/pointer-compute.ts
@@ -17,6 +17,7 @@ function is_valid_target(target: EventTarget | null): target is HTMLElement {
 
 function compute_target_offset(event: DomEvent, target: HTMLElement): { x: number; y: number } {
 	const rect = target.getBoundingClientRect()
+
 	return { x: event.clientX - rect.left, y: event.clientY - rect.top }
 }
 
@@ -27,8 +28,10 @@ export function make_pointer_compute(
 		if (!is_valid_target(event.target)) return
 		const { clientWidth: w, clientHeight: h } = event.target
 		const { x, y } = compute_target_offset(event, event.target)
+
 		ctx.pointer.update((p) => {
 			p.set((x / w) * NDC_SCALE - 1, -(y / h) * NDC_SCALE + 1)
+
 			return p
 		})
 		ctx.raycaster.setFromCamera(ctx.pointer.current, camera.current)

--- a/src/lib/game-kit/listener-manager.svelte.test.ts
+++ b/src/lib/game-kit/listener-manager.svelte.test.ts
@@ -18,11 +18,13 @@ describe('create_listener_manager', () => {
 
 	it('is_active is false before setup', () => {
 		const manager = create_listener_manager([spec])
+
 		expect(manager.is_active).toBe(false)
 	})
 
 	it('is_active is true after setup', () => {
 		const manager = create_listener_manager([spec])
+
 		manager.setup()
 		expect(manager.is_active).toBe(true)
 	})
@@ -30,6 +32,7 @@ describe('create_listener_manager', () => {
 	it('is_active is false after cleanup', () => {
 		const manager = create_listener_manager([spec])
 		const cleanup = manager.setup()
+
 		cleanup()
 		expect(manager.is_active).toBe(false)
 	})
@@ -37,6 +40,7 @@ describe('create_listener_manager', () => {
 	it('setup registers the listener on the target', () => {
 		const manager = create_listener_manager([spec])
 		const add_spy = vi.spyOn(target, 'addEventListener')
+
 		manager.setup()
 		expect(add_spy).toHaveBeenCalledWith('click', spy, undefined)
 	})
@@ -45,12 +49,14 @@ describe('create_listener_manager', () => {
 		const manager = create_listener_manager([spec])
 		const remove_spy = vi.spyOn(target, 'removeEventListener')
 		const cleanup = manager.setup()
+
 		cleanup()
 		expect(remove_spy).toHaveBeenCalledWith('click', spy, undefined)
 	})
 
 	it('listener is active after setup — target receives events', () => {
 		const manager = create_listener_manager([spec])
+
 		manager.setup()
 		;(target as HTMLElement).dispatchEvent(new Event('click'))
 		expect(spy).toHaveBeenCalledTimes(1)
@@ -59,6 +65,7 @@ describe('create_listener_manager', () => {
 	it('listener is inactive after cleanup — target no longer receives events', () => {
 		const manager = create_listener_manager([spec])
 		const cleanup = manager.setup()
+
 		cleanup()
 		;(target as HTMLElement).dispatchEvent(new Event('click'))
 		expect(spy).not.toHaveBeenCalled()
@@ -68,12 +75,14 @@ describe('create_listener_manager', () => {
 		const manager = create_listener_manager([spec])
 		const a = manager.setup()
 		const b = manager.setup()
+
 		expect(a).toBe(b)
 	})
 
 	it('double setup does not register listener twice', () => {
 		const manager = create_listener_manager([spec])
 		const add_spy = vi.spyOn(target, 'addEventListener')
+
 		manager.setup()
 		manager.setup()
 		expect(add_spy).toHaveBeenCalledTimes(1)
@@ -83,6 +92,7 @@ describe('create_listener_manager', () => {
 		const on_cleanup = vi.fn()
 		const manager = create_listener_manager([spec])
 		const cleanup = manager.setup(on_cleanup)
+
 		cleanup()
 		expect(on_cleanup).toHaveBeenCalledTimes(1)
 	})
@@ -90,6 +100,7 @@ describe('create_listener_manager', () => {
 	it('on_cleanup is not called if setup was never called', () => {
 		const on_cleanup = vi.fn()
 		const manager = create_listener_manager([spec])
+
 		manager.setup(on_cleanup)
 		expect(on_cleanup).not.toHaveBeenCalled()
 	})
@@ -103,6 +114,7 @@ describe('create_listener_manager', () => {
 		}
 		const manager = create_listener_manager([capture_spec])
 		const add_spy = vi.spyOn(target, 'addEventListener')
+
 		manager.setup()
 		expect(add_spy).toHaveBeenCalledWith('click', spy, { capture: true })
 	})
@@ -112,6 +124,7 @@ describe('create_listener_manager', () => {
 		const spec2: ListenerSpec = { target, type: 'mousedown', handler: spy2 as EventListener }
 		const manager = create_listener_manager([spec, spec2])
 		const add_spy = vi.spyOn(target, 'addEventListener')
+
 		manager.setup()
 		expect(add_spy).toHaveBeenCalledTimes(2)
 	})
@@ -122,6 +135,7 @@ describe('create_listener_manager', () => {
 		const manager = create_listener_manager([spec, spec2])
 		const remove_spy = vi.spyOn(target, 'removeEventListener')
 		const cleanup = manager.setup()
+
 		cleanup()
 		expect(remove_spy).toHaveBeenCalledTimes(2)
 	})
@@ -129,8 +143,10 @@ describe('create_listener_manager', () => {
 	it('can be set up again after cleanup', () => {
 		const manager = create_listener_manager([spec])
 		const cleanup = manager.setup()
+
 		cleanup()
 		const cleanup2 = manager.setup()
+
 		expect(manager.is_active).toBe(true)
 		cleanup2()
 	})

--- a/src/lib/game-kit/listener-manager.ts
+++ b/src/lib/game-kit/listener-manager.ts
@@ -7,6 +7,7 @@ export type ListenerSpec = {
 
 export function create_listener_manager(specs: ReadonlyArray<ListenerSpec>) {
 	let cleanup_fn: (() => void) | null = null
+
 	return {
 		get is_active(): boolean {
 			return cleanup_fn !== null
@@ -14,12 +15,14 @@ export function create_listener_manager(specs: ReadonlyArray<ListenerSpec>) {
 		setup(on_cleanup?: () => void): () => void {
 			if (cleanup_fn) return cleanup_fn
 			for (const spec of specs) spec.target.addEventListener(spec.type, spec.handler, spec.options)
+
 			cleanup_fn = function cleanup(): void {
 				for (const spec of specs)
 					spec.target.removeEventListener(spec.type, spec.handler, spec.options)
 				cleanup_fn = null
 				on_cleanup?.()
 			}
+
 			return cleanup_fn
 		},
 	}

--- a/src/lib/game-kit/loading.svelte.test.ts
+++ b/src/lib/game-kit/loading.svelte.test.ts
@@ -140,6 +140,7 @@ describe('create_loading isolation', () => {
 		vi.useFakeTimers()
 		const a = create_loading<DefaultLoadingStep>('downloading')
 		const b = create_loading<DefaultLoadingStep>('downloading')
+
 		a.mark_ready()
 		vi.advanceTimersByTime(MIN_DISPLAY_MS)
 		expect(a.is_visible).toBe(false)
@@ -150,6 +151,7 @@ describe('create_loading isolation', () => {
 	it('two instances do not share current_step state', () => {
 		const a = create_loading<DefaultLoadingStep>('downloading')
 		const b = create_loading<DefaultLoadingStep>('downloading')
+
 		a.configure({ downloading: 'd', initializing: 'i', loading_assets: 'l', ready: 'r' })
 		b.configure({ downloading: 'd', initializing: 'i', loading_assets: 'l', ready: 'r' })
 		a.set_step('initializing')

--- a/src/lib/game-kit/loading.svelte.ts
+++ b/src/lib/game-kit/loading.svelte.ts
@@ -23,6 +23,7 @@ type LoadingRefs = { hide_timer_id: ReturnType<typeof setTimeout> | null }
 function disconnect_observer(): void {
 	const scope = globalThis as Record<string, unknown>
 	const observer = scope[OBSERVER_GLOBAL_KEY] as LoadingObserver | undefined
+
 	if (observer && typeof observer.disconnect === 'function') {
 		observer.disconnect()
 		scope[OBSERVER_GLOBAL_KEY] = undefined
@@ -59,6 +60,7 @@ function reset_impl<T extends string>(
 		clearTimeout(refs.hide_timer_id)
 		refs.hide_timer_id = null
 	}
+
 	disconnect_observer()
 	s.is_visible = true
 	s.progress = INITIAL_PROGRESS
@@ -78,6 +80,7 @@ export function create_loading<T extends string>(initial_step: T) {
 		progress_value: 0,
 	})
 	const refs: LoadingRefs = { hide_timer_id: null }
+
 	return {
 		get is_visible() {
 			return s.is_visible

--- a/src/lib/game-kit/pixel-dpr.test.ts
+++ b/src/lib/game-kit/pixel-dpr.test.ts
@@ -20,6 +20,7 @@ describe('compute_pixel_dpr — SHORTER-based target with SHORTER-based floor', 
 		)
 		const shorter = Math.min(viewport_w, viewport_h)
 		const buffer_short = shorter * dpr
+
 		expect(buffer_short).toBeCloseTo(TARGET_SHORT, 6)
 	})
 
@@ -35,6 +36,7 @@ describe('compute_pixel_dpr — SHORTER-based target with SHORTER-based floor', 
 			MAX_DPR,
 			FALLBACK,
 		)
+
 		expect(dpr).toBe(MAX_DPR)
 	})
 
@@ -50,8 +52,10 @@ describe('compute_pixel_dpr — SHORTER-based target with SHORTER-based floor', 
 			MAX_DPR,
 			FALLBACK,
 		)
+
 		expect(dpr).toBeGreaterThan(MAX_DPR)
 		const buffer_short = Math.min(viewport_w, viewport_h) * dpr
+
 		expect(buffer_short).toBeCloseTo(MIN_SHORT, 6)
 	})
 
@@ -64,9 +68,11 @@ describe('compute_pixel_dpr — SHORTER-based target with SHORTER-based floor', 
 			{ w: 200, h: 400 },
 			{ w: 80, h: 160 },
 		]
+
 		for (const { w, h } of cases) {
 			const dpr = compute_pixel_dpr(w, h, TARGET_SHORT, MIN_SHORT, MAX_DPR, FALLBACK)
 			const shorter_buffer = Math.min(w, h) * dpr
+
 			expect(shorter_buffer).toBeGreaterThanOrEqual(MIN_SHORT - 1e-9)
 		}
 	})
@@ -82,6 +88,7 @@ describe('compute_pixel_dpr — SHORTER-based target with SHORTER-based floor', 
 			MAX_DPR,
 			FALLBACK,
 		)
+
 		expect(dpr).toBeCloseTo(TARGET_SHORT / viewport_w, 10)
 	})
 

--- a/src/lib/game-kit/pixel-dpr.ts
+++ b/src/lib/game-kit/pixel-dpr.ts
@@ -11,6 +11,7 @@ function compute_pixel_dpr(
 	const target_dpr = target_short_edge / shorter
 	const min_dpr = min_short_edge / shorter
 	const capped_dpr = Math.min(max_dpr, target_dpr)
+
 	return Math.max(min_dpr, capped_dpr)
 }
 

--- a/src/lib/game-kit/player/Player.svelte
+++ b/src/lib/game-kit/player/Player.svelte
@@ -43,6 +43,7 @@
 		const kb_len = Math.hypot(kb_f, kb_s)
 		const norm_f = kb_len > 1 ? kb_f / kb_len : kb_f
 		const norm_s = kb_len > 1 ? kb_s / kb_len : kb_s
+
 		return {
 			forward: norm_f * KEYBOARD_AXIS_FRACTION + input.joystick_move.y,
 			strafe: norm_s * KEYBOARD_AXIS_FRACTION + input.joystick_move.x,
@@ -53,6 +54,7 @@
 		const raw_x = pos_x + vel_x * delta
 		const raw_z = pos_z + vel_z * delta
 		const clamped = player_bounds.clamp_to_room(raw_x, raw_z)
+
 		pos_x = clamped.x
 		pos_z = clamped.z
 	}
@@ -91,10 +93,12 @@
 			strafe,
 			is_sprinting: input.is_sprinting,
 		})
+
 		if (result.look_consumed) {
 			input.apply_look_delta(result.delta_yaw, result.delta_pitch)
 			input.set_joystick_look(0, 0)
 		}
+
 		apply_movement(result.velocity.x, result.velocity.z, delta)
 		apply_jump_step(delta)
 		update_shake(delta)

--- a/src/lib/game-kit/player/Player.svelte.test.ts
+++ b/src/lib/game-kit/player/Player.svelte.test.ts
@@ -68,6 +68,7 @@ describe('Player', () => {
 
 	it('renders without error when not in gameover', () => {
 		const { container } = render(Player, { props: { is_gameover: false } })
+
 		expect(container).toBeTruthy()
 	})
 
@@ -88,6 +89,7 @@ describe('Player', () => {
 		render(Player, { props: { is_gameover: false } })
 		tick_holder.fn?.(0.016)
 		const call = vi.mocked(player_step.compute_velocity_after_look).mock.calls[0]?.[0]
+
 		expect(call?.forward).toBeCloseTo(KEYBOARD_AXIS_FRACTION)
 	})
 
@@ -96,6 +98,7 @@ describe('Player', () => {
 		render(Player, { props: { is_gameover: false } })
 		tick_holder.fn?.(0.016)
 		const call = vi.mocked(player_step.compute_velocity_after_look).mock.calls[0]?.[0]
+
 		expect(call?.forward).toBeCloseTo(KEYBOARD_AXIS_FRACTION / Math.SQRT2)
 	})
 
@@ -104,6 +107,7 @@ describe('Player', () => {
 		render(Player, { props: { is_gameover: false } })
 		tick_holder.fn?.(0.016)
 		const call = vi.mocked(player_step.compute_velocity_after_look).mock.calls[0]?.[0]
+
 		expect(call?.forward).toBeCloseTo(1)
 	})
 })

--- a/src/lib/game-kit/player/camera-shake.svelte.test.ts
+++ b/src/lib/game-kit/player/camera-shake.svelte.test.ts
@@ -47,6 +47,7 @@ describe('camera_shake', () => {
 		camera_shake.trigger(STRONG)
 		camera_shake.step(DELTA)
 		const expected = STRONG - STRONG * DECAY_RATE * DELTA
+
 		expect(camera_shake.intensity).toBeCloseTo(expected, 6)
 	})
 
@@ -58,16 +59,20 @@ describe('camera_shake', () => {
 
 	it('sample_position_offset stays within ±MAX_POSITION_OFFSET when active', () => {
 		camera_shake.trigger(STRONG)
+
 		for (let i = 0; i < 100; i++) {
 			const v = camera_shake.sample_position_offset()
+
 			expect(Math.abs(v)).toBeLessThanOrEqual(MAX_POSITION_OFFSET + Number.EPSILON)
 		}
 	})
 
 	it('sample_rotation_offset stays within ±MAX_ROTATION_OFFSET when active', () => {
 		camera_shake.trigger(STRONG)
+
 		for (let i = 0; i < 100; i++) {
 			const v = camera_shake.sample_rotation_offset()
+
 			expect(Math.abs(v)).toBeLessThanOrEqual(MAX_ROTATION_OFFSET + Number.EPSILON)
 		}
 	})

--- a/src/lib/game-kit/player/camera-shake.svelte.ts
+++ b/src/lib/game-kit/player/camera-shake.svelte.ts
@@ -15,6 +15,7 @@ function reset(): void {
 
 function sample(max: number): number {
 	if (intensity <= 0) return 0
+
 	return (Math.random() * 2 - 1) * max * intensity // NOSONAR — visual animation only
 }
 

--- a/src/lib/game-kit/player/player-bounds.test.ts
+++ b/src/lib/game-kit/player/player-bounds.test.ts
@@ -4,38 +4,45 @@ import { describe, expect, it } from 'vitest'
 describe('player_bounds', () => {
 	it('does not clamp position inside the room', () => {
 		const result = player_bounds.clamp_to_room(0, 0)
+
 		expect(result.x).toBe(0)
 		expect(result.z).toBe(0)
 	})
 
 	it('clamps x when past the right wall', () => {
 		const result = player_bounds.clamp_to_room(10, 0)
+
 		expect(result.x).toBe(player_bounds.X_MAX)
 	})
 
 	it('clamps x when past the left wall', () => {
 		const result = player_bounds.clamp_to_room(-10, 0)
+
 		expect(result.x).toBe(-player_bounds.X_MAX)
 	})
 
 	it('clamps z when past the back wall', () => {
 		const result = player_bounds.clamp_to_room(0, -10)
+
 		expect(result.z).toBe(-player_bounds.Z_MAX)
 	})
 
 	it('clamps z when past the front wall', () => {
 		const result = player_bounds.clamp_to_room(0, 10)
+
 		expect(result.z).toBe(player_bounds.Z_MAX)
 	})
 
 	it('does not clamp position exactly at the boundary', () => {
 		const { x, z } = player_bounds.clamp_to_room(player_bounds.X_MAX, player_bounds.Z_MAX)
+
 		expect(x).toBe(player_bounds.X_MAX)
 		expect(z).toBe(player_bounds.Z_MAX)
 	})
 
 	it('clamps position one unit past the boundary', () => {
 		const { x, z } = player_bounds.clamp_to_room(player_bounds.X_MAX + 1, player_bounds.Z_MAX + 1)
+
 		expect(x).toBe(player_bounds.X_MAX)
 		expect(z).toBe(player_bounds.Z_MAX)
 	})

--- a/src/lib/game-kit/player/player-jump.test.ts
+++ b/src/lib/game-kit/player/player-jump.test.ts
@@ -14,6 +14,7 @@ describe('player_jump.step_jump', () => {
 			ground_y: GROUND_Y,
 		})
 		const expected_vel = player_jump.JUMP_VELOCITY - player_jump.JUMP_GRAVITY * DT
+
 		expect(result.new_vel_y).toBeCloseTo(expected_vel)
 		expect(result.jump_consumed).toBe(true)
 		expect(result.new_pos_y).toBeGreaterThan(GROUND_Y)
@@ -27,6 +28,7 @@ describe('player_jump.step_jump', () => {
 			is_jump_requested: false,
 			ground_y: GROUND_Y,
 		})
+
 		expect(result.jump_consumed).toBe(false)
 	})
 
@@ -38,6 +40,7 @@ describe('player_jump.step_jump', () => {
 			is_jump_requested: false,
 			ground_y: GROUND_Y,
 		})
+
 		expect(result.new_pos_y).toBe(GROUND_Y)
 		expect(result.new_vel_y).toBe(0)
 	})
@@ -51,6 +54,7 @@ describe('player_jump.step_jump', () => {
 			ground_y: GROUND_Y,
 		})
 		const expected_vel = 5 - player_jump.JUMP_GRAVITY * DT
+
 		expect(result.new_vel_y).toBeCloseTo(expected_vel)
 		expect(result.new_pos_y).toBeCloseTo(GROUND_Y + 1 + expected_vel * DT)
 	})
@@ -64,6 +68,7 @@ describe('player_jump.step_jump', () => {
 			ground_y: GROUND_Y,
 		})
 		const expected_vel = 2 - player_jump.JUMP_GRAVITY * DT
+
 		expect(result.new_vel_y).toBeCloseTo(expected_vel)
 		expect(result.jump_consumed).toBe(true)
 	})
@@ -76,6 +81,7 @@ describe('player_jump.step_jump', () => {
 			is_jump_requested: false,
 			ground_y: GROUND_Y,
 		})
+
 		expect(result.new_pos_y).toBe(GROUND_Y)
 		expect(result.new_vel_y).toBe(0)
 	})

--- a/src/lib/game-kit/player/player-jump.ts
+++ b/src/lib/game-kit/player/player-jump.ts
@@ -18,15 +18,19 @@ type JumpResult = {
 function step_jump(jump_input: JumpInput): JumpResult {
 	let vel_y = jump_input.vel_y
 	let jump_consumed = false
+
 	if (jump_input.is_jump_requested) {
 		if (vel_y === 0) vel_y = JUMP_VELOCITY
 		jump_consumed = true
 	}
+
 	vel_y -= JUMP_GRAVITY * jump_input.delta
 	const new_pos_y = jump_input.pos_y + vel_y * jump_input.delta
+
 	if (new_pos_y <= jump_input.ground_y) {
 		return { new_pos_y: jump_input.ground_y, new_vel_y: 0, jump_consumed }
 	}
+
 	return { new_pos_y, new_vel_y: vel_y, jump_consumed }
 }
 

--- a/src/lib/game-kit/player/player-speed.ts
+++ b/src/lib/game-kit/player/player-speed.ts
@@ -3,6 +3,7 @@ const SPRINT_MULTIPLIER = 2
 
 function get_move_speed(is_sprinting: boolean): number {
 	if (is_sprinting) return MOVE_SPEED * SPRINT_MULTIPLIER
+
 	return MOVE_SPEED
 }
 

--- a/src/lib/game-kit/player/player-step.test.ts
+++ b/src/lib/game-kit/player/player-step.test.ts
@@ -20,6 +20,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		// forward at yaw=PI/2 rotates: fw_x = -sin(PI/2) = -1, fw_z = -cos(PI/2) = 0
 		// If the function used the pre-look yaw=0, velocity would be (0, 0, -MOVE_SPEED).
 		expect(result.velocity.x).toBeCloseTo(-MOVE_SPEED)
@@ -37,6 +38,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		// forward at yaw=0: velocity = (0, 0, -MOVE_SPEED)
 		expect(result.velocity.x).toBeCloseTo(0)
 		expect(result.velocity.z).toBeCloseTo(-MOVE_SPEED)
@@ -54,6 +56,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.delta_yaw).toBeCloseTo(joystick_look_x * LOOK_SPEED * DELTA)
 	})
 
@@ -69,6 +72,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.delta_pitch).toBeCloseTo(-joystick_look_y * LOOK_SPEED * DELTA)
 	})
 
@@ -83,6 +87,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.delta_pitch).toBeLessThan(0)
 	})
 
@@ -97,6 +102,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.look_consumed).toBe(true)
 	})
 
@@ -111,6 +117,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.look_consumed).toBe(true)
 	})
 
@@ -125,6 +132,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.look_consumed).toBe(false)
 	})
 
@@ -139,6 +147,7 @@ describe('player_step.compute_velocity_after_look', () => {
 			strafe: 0,
 			is_sprinting: true,
 		})
+
 		expect(result.velocity.z).toBeCloseTo(-MOVE_SPEED * player_speed.SPRINT_MULTIPLIER)
 	})
 })

--- a/src/lib/game-kit/player/player-step.ts
+++ b/src/lib/game-kit/player/player-step.ts
@@ -30,6 +30,7 @@ function compute_velocity_after_look(step_input: StepInput): StepResult {
 		is_sprinting: step_input.is_sprinting,
 	})
 	const look_consumed = step_input.joystick_look_x !== 0 || step_input.joystick_look_y !== 0
+
 	return { velocity, delta_yaw, delta_pitch, look_consumed }
 }
 

--- a/src/lib/game-kit/player/player-velocity.test.ts
+++ b/src/lib/game-kit/player/player-velocity.test.ts
@@ -13,6 +13,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.x).toBeCloseTo(0)
 		expect(result.y).toBe(0)
 		expect(result.z).toBeCloseTo(0)
@@ -25,6 +26,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.x).toBeCloseTo(0)
 		expect(result.z).toBeCloseTo(-NORMAL_SPEED)
 		expect(result.y).toBe(0)
@@ -37,6 +39,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: 1,
 			is_sprinting: false,
 		})
+
 		expect(result.x).toBeCloseTo(NORMAL_SPEED)
 		expect(result.z).toBeCloseTo(0)
 	})
@@ -49,6 +52,7 @@ describe('player_velocity.compute_velocity', () => {
 			is_sprinting: false,
 		})
 		const len = Math.hypot(result.x, result.z)
+
 		expect(len).toBeCloseTo(NORMAL_SPEED)
 	})
 
@@ -59,6 +63,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.z).toBeCloseTo(-0.5 * NORMAL_SPEED)
 	})
 
@@ -69,6 +74,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: 0,
 			is_sprinting: true,
 		})
+
 		expect(result.z).toBeCloseTo(-SPRINT_SPEED)
 	})
 
@@ -79,6 +85,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: 0,
 			is_sprinting: false,
 		})
+
 		expect(result.x).toBeCloseTo(-NORMAL_SPEED)
 		expect(result.z).toBeCloseTo(0)
 	})
@@ -90,6 +97,7 @@ describe('player_velocity.compute_velocity', () => {
 			strafe: -0.5,
 			is_sprinting: true,
 		})
+
 		expect(result.y).toBe(0)
 	})
 })

--- a/src/lib/game-kit/player/player-velocity.ts
+++ b/src/lib/game-kit/player/player-velocity.ts
@@ -20,6 +20,7 @@ function compute_velocity(velocity_input: VelocityInput): Velocity {
 	const nx = len > 1 ? vx / len : vx
 	const nz = len > 1 ? vz / len : vz
 	const speed = player_speed.get_move_speed(velocity_input.is_sprinting)
+
 	return { x: nx * speed, y: 0, z: nz * speed }
 }
 

--- a/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
+++ b/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
@@ -20,6 +20,7 @@ describe('FloorCredits', () => {
 				scroll_end_z: END_Z,
 			},
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -32,6 +33,7 @@ describe('FloorCredits', () => {
 				scroll_end_z: END_Z,
 			},
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -39,6 +41,7 @@ describe('FloorCredits', () => {
 		const { container } = render(FloorCredits, {
 			props: { is_alt: false, credits: '', scroll_start_z: START_Z, scroll_end_z: END_Z },
 		})
+
 		expect(container).toBeTruthy()
 	})
 })

--- a/src/lib/game-kit/scene/Room.svelte.test.ts
+++ b/src/lib/game-kit/scene/Room.svelte.test.ts
@@ -11,11 +11,13 @@ describe('Room', () => {
 		const { container } = render(Room, {
 			props: { ...COLORS, width: 10, depth: 10, height: 3 },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
 	it('renders with default dimensions (no width/depth/height)', () => {
 		const { container } = render(Room, { props: COLORS })
+
 		expect(container).toBeTruthy()
 	})
 
@@ -23,6 +25,7 @@ describe('Room', () => {
 		const { container } = render(Room, {
 			props: { ...COLORS, width: 20, depth: 15, height: 5 },
 		})
+
 		expect(container).toBeTruthy()
 	})
 })

--- a/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
+++ b/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
@@ -104,6 +104,7 @@ describe('SceneObjects', () => {
 	it('renders without error with a game_board snippet', () => {
 		const game_board = createRawSnippet(() => ({ render: () => '<span></span>' }))
 		const { container } = render(SceneObjects, { props: make_props(game_board) })
+
 		expect(container).toBeTruthy()
 	})
 
@@ -112,12 +113,14 @@ describe('SceneObjects', () => {
 			render: () => '<span data-testid="board-slot"></span>',
 		}))
 		const { container } = render(SceneObjects, { props: make_props(game_board) })
+
 		expect(container.querySelector('[data-testid="board-slot"]')).toBeTruthy()
 	})
 
 	it('renders with default props without error', () => {
 		const game_board = createRawSnippet(() => ({ render: () => '<span></span>' }))
 		const { container } = render(SceneObjects, { props: make_props(game_board) })
+
 		expect(container).toBeTruthy()
 	})
 })

--- a/src/lib/game-kit/scene/credits-config.test.ts
+++ b/src/lib/game-kit/scene/credits-config.test.ts
@@ -61,28 +61,33 @@ describe('credits-config', () => {
 	describe('make_credits_scroll_bounds', () => {
 		it('start_z is positive', () => {
 			const { start_z } = credits_scroll.make_credits_scroll_bounds(10, TEST_HALF_DEPTH)
+
 			expect(start_z).toBeGreaterThan(0)
 		})
 
 		it('end_z is negative', () => {
 			const { end_z } = credits_scroll.make_credits_scroll_bounds(10, TEST_HALF_DEPTH)
+
 			expect(end_z).toBeLessThan(0)
 		})
 
 		it('start_z and end_z are symmetric around zero', () => {
 			const { start_z, end_z } = credits_scroll.make_credits_scroll_bounds(10, TEST_HALF_DEPTH)
+
 			expect(start_z).toBeCloseTo(-end_z)
 		})
 
 		it('start_z increases as line_count increases', () => {
 			const small = credits_scroll.make_credits_scroll_bounds(10, TEST_HALF_DEPTH)
 			const large = credits_scroll.make_credits_scroll_bounds(100, TEST_HALF_DEPTH)
+
 			expect(large.start_z).toBeGreaterThan(small.start_z)
 		})
 
 		it('start_z increases as half_depth increases', () => {
 			const shallow = credits_scroll.make_credits_scroll_bounds(10, 1)
 			const deep = credits_scroll.make_credits_scroll_bounds(10, 10)
+
 			expect(deep.start_z).toBeGreaterThan(shallow.start_z)
 		})
 	})
@@ -101,11 +106,13 @@ describe('credits-config', () => {
 				END_Z,
 				CREDITS_SCROLL_SPEED,
 			)
+
 			expect(result).toBeCloseTo(initial_z - CREDITS_SCROLL_SPEED * FRAME_DELTA)
 		})
 
 		it('resets to start_z when z drops below end_z', () => {
 			const past_end = END_Z - 0.1
+
 			expect(credits_scroll.advance_scroll(past_end, 0, START_Z, END_Z, CREDITS_SCROLL_SPEED)).toBe(
 				START_Z,
 			)
@@ -120,6 +127,7 @@ describe('credits-config', () => {
 		it('continues scrolling when z is above end_z', () => {
 			const z = 0
 			const result = credits_scroll.advance_scroll(z, 1, START_Z, END_Z, CREDITS_SCROLL_SPEED)
+
 			expect(result).toBeLessThan(z)
 			expect(result).not.toBe(START_Z)
 		})
@@ -128,6 +136,7 @@ describe('credits-config', () => {
 			const initial_z = 5
 			const slow = credits_scroll.advance_scroll(initial_z, FRAME_DELTA, START_Z, END_Z, 0.1)
 			const fast = credits_scroll.advance_scroll(initial_z, FRAME_DELTA, START_Z, END_Z, 1)
+
 			expect(fast).toBeLessThan(slow)
 		})
 	})

--- a/src/lib/game-kit/scene/credits-config.ts
+++ b/src/lib/game-kit/scene/credits-config.ts
@@ -16,6 +16,7 @@ export function make_credits_scroll_bounds(
 ): { start_z: number; end_z: number } {
 	const height = line_count * CREDITS_FONT_SIZE * CREDITS_LINE_HEIGHT
 	const offset = half_depth + height / HALF_DIVISOR
+
 	return { start_z: offset, end_z: -offset }
 }
 
@@ -27,6 +28,7 @@ export function advance_scroll(
 	speed: number,
 ): number {
 	const next_z = current_z - speed * delta
+
 	return next_z < end_z ? start_z : next_z
 }
 

--- a/src/lib/game-kit/session.test.ts
+++ b/src/lib/game-kit/session.test.ts
@@ -32,6 +32,7 @@ describe('create_session isolation', () => {
 	it('two instances do not share is_session_started state', () => {
 		const a = create_session()
 		const b = create_session()
+
 		a.start_session()
 		expect(a.is_session_started).toBe(true)
 		expect(b.is_session_started).toBe(false)

--- a/src/lib/game-kit/state.test.ts
+++ b/src/lib/game-kit/state.test.ts
@@ -43,6 +43,7 @@ describe('create_game_state isolation', () => {
 	it('two instances do not share is_alt state', () => {
 		const a = create_game_state()
 		const b = create_game_state()
+
 		a.toggle_alt()
 		expect(a.is_alt).toBe(true)
 		expect(b.is_alt).toBe(false)

--- a/src/lib/game-kit/switch/Switch.svelte
+++ b/src/lib/game-kit/switch/Switch.svelte
@@ -35,6 +35,7 @@
 
 	function make_bar(sx: CornerSign, sy: CornerSign, axis: BarAxis, g: CornerGeom): CornerBar {
 		const is_h = axis === 'h'
+
 		return {
 			key: `${axis}${sx}${sy}`,
 			px: sx * (is_h ? g.arm_center : g.pos),

--- a/src/lib/game-kit/switch/Switch.svelte.test.ts
+++ b/src/lib/game-kit/switch/Switch.svelte.test.ts
@@ -28,6 +28,7 @@ const BASE_PROPS = {
 describe('Switch', () => {
 	it('renders cyber icon without geometry override', () => {
 		const { container } = render(Switch, { props: BASE_PROPS })
+
 		expect(container).toBeTruthy()
 	})
 
@@ -35,6 +36,7 @@ describe('Switch', () => {
 		const { container } = render(Switch, {
 			props: { ...BASE_PROPS, icon_type: 'fullscreen' as const },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -42,6 +44,7 @@ describe('Switch', () => {
 		const { container } = render(Switch, {
 			props: { ...BASE_PROPS, icon_type: 'crt' as const },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -49,6 +52,7 @@ describe('Switch', () => {
 		const { container } = render(Switch, {
 			props: { ...BASE_PROPS, is_active: true },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -57,6 +61,7 @@ describe('Switch', () => {
 		const { container } = render(Switch, {
 			props: { ...BASE_PROPS, geometry },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -95,6 +100,7 @@ describe('Switch', () => {
 			active_light_intensity: ACTIVE_LIGHT_INTENSITY,
 		}
 		const { container } = render(Switch, { props: { ...BASE_PROPS, geometry } })
+
 		expect(container).toBeTruthy()
 	})
 })

--- a/src/lib/game-kit/switch/alt-switch-input.test.ts
+++ b/src/lib/game-kit/switch/alt-switch-input.test.ts
@@ -35,12 +35,14 @@ describe('alt_switch_input', () => {
 	it('plays switch click sound when session is started', () => {
 		session.start_session()
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		alt_switch_input.on_click()
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not play switch click sound when session is not started', () => {
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		alt_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()
 	})

--- a/src/lib/game-kit/switch/crt-switch-input.test.ts
+++ b/src/lib/game-kit/switch/crt-switch-input.test.ts
@@ -35,12 +35,14 @@ describe('crt_switch_input', () => {
 	it('plays switch click sound when session is started', () => {
 		session.start_session()
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		crt_switch_input.on_click()
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not play switch click sound when session is not started', () => {
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		crt_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()
 	})

--- a/src/lib/game-kit/switch/fps-switch-input.test.ts
+++ b/src/lib/game-kit/switch/fps-switch-input.test.ts
@@ -35,12 +35,14 @@ describe('fps_switch_input', () => {
 	it('plays switch click sound when session is started', () => {
 		session.start_session()
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		fps_switch_input.on_click()
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not play switch click sound when session is not started', () => {
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		fps_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()
 	})

--- a/src/lib/game-kit/switch/fullscreen-switch-input.svelte.test.ts
+++ b/src/lib/game-kit/switch/fullscreen-switch-input.svelte.test.ts
@@ -27,6 +27,7 @@ describe('fullscreen_switch_input', () => {
 	it('does nothing when session is not started', () => {
 		const request_spy = vi.spyOn(fullscreen, 'request').mockResolvedValue()
 		const exit_spy = vi.spyOn(fullscreen, 'exit').mockResolvedValue()
+
 		fullscreen_switch_input.on_click()
 		expect(request_spy).not.toHaveBeenCalled()
 		expect(exit_spy).not.toHaveBeenCalled()
@@ -36,6 +37,7 @@ describe('fullscreen_switch_input', () => {
 		fullscreen_switch_input.set_container(null)
 		session.start_session()
 		const request_spy = vi.spyOn(fullscreen, 'request').mockResolvedValue()
+
 		fullscreen_switch_input.on_click()
 		expect(request_spy).not.toHaveBeenCalled()
 	})
@@ -43,6 +45,7 @@ describe('fullscreen_switch_input', () => {
 	it('requests fullscreen when inactive', () => {
 		session.start_session()
 		const request_spy = vi.spyOn(fullscreen, 'request').mockResolvedValue()
+
 		fullscreen_switch_input.on_click()
 		expect(request_spy).toHaveBeenCalledWith(container)
 	})
@@ -51,6 +54,7 @@ describe('fullscreen_switch_input', () => {
 		session.start_session()
 		vi.spyOn(fullscreen, 'is_active', 'get').mockReturnValue(true)
 		const exit_spy = vi.spyOn(fullscreen, 'exit').mockResolvedValue()
+
 		fullscreen_switch_input.on_click()
 		expect(exit_spy).toHaveBeenCalledTimes(1)
 	})
@@ -58,6 +62,7 @@ describe('fullscreen_switch_input', () => {
 	it('plays switch click sound when session is started and container is set', () => {
 		session.start_session()
 		const sound_spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		vi.spyOn(fullscreen, 'request').mockResolvedValue()
 		fullscreen_switch_input.on_click()
 		expect(sound_spy).toHaveBeenCalledTimes(1)
@@ -65,6 +70,7 @@ describe('fullscreen_switch_input', () => {
 
 	it('does not play sound when session is not started', () => {
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		fullscreen_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()
 	})
@@ -73,6 +79,7 @@ describe('fullscreen_switch_input', () => {
 		fullscreen_switch_input.set_container(null)
 		session.start_session()
 		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+
 		fullscreen_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()
 	})

--- a/src/lib/game-kit/switch/switch-audio.test.ts
+++ b/src/lib/game-kit/switch/switch-audio.test.ts
@@ -23,6 +23,7 @@ describe('switch_audio.play_switch_click', () => {
 
 	it('is a no-op before init is called', async () => {
 		const { switch_audio } = await import('./switch-audio.js')
+
 		switch_audio.play_switch_click()
 		expect(play_mock).not.toHaveBeenCalled()
 	})
@@ -30,12 +31,14 @@ describe('switch_audio.play_switch_click', () => {
 	it('does not throw when Audio is unavailable', async () => {
 		vi.stubGlobal('Audio', undefined)
 		const { switch_audio } = await import('./switch-audio.js')
+
 		switch_audio.init(MOCK_URL)
 		expect(() => switch_audio.play_switch_click()).not.toThrow()
 	})
 
 	it('calls play on the audio element', async () => {
 		const { switch_audio } = await import('./switch-audio.js')
+
 		switch_audio.init(MOCK_URL)
 		switch_audio.play_switch_click()
 		expect(play_mock).toHaveBeenCalledTimes(1)
@@ -43,6 +46,7 @@ describe('switch_audio.play_switch_click', () => {
 
 	it('resets currentTime to 0 before playing', async () => {
 		const { switch_audio } = await import('./switch-audio.js')
+
 		switch_audio.init(MOCK_URL)
 		switch_audio.play_switch_click()
 		shared_instance.currentTime = 99
@@ -52,6 +56,7 @@ describe('switch_audio.play_switch_click', () => {
 
 	it('reuses the same Audio instance across calls', async () => {
 		const { switch_audio } = await import('./switch-audio.js')
+
 		switch_audio.init(MOCK_URL)
 		switch_audio.play_switch_click()
 		switch_audio.play_switch_click()
@@ -60,6 +65,7 @@ describe('switch_audio.play_switch_click', () => {
 
 	it('creates Audio with the correct URL', async () => {
 		const { switch_audio } = await import('./switch-audio.js')
+
 		switch_audio.init(MOCK_URL)
 		switch_audio.play_switch_click()
 		expect(audio_ctor).toHaveBeenCalledWith(MOCK_URL)

--- a/src/lib/game-kit/switch/switch-colors.test.ts
+++ b/src/lib/game-kit/switch/switch-colors.test.ts
@@ -23,6 +23,7 @@ const TEST_COLORS: SwitchColors = {
 describe('resolve_switch_colors', () => {
 	it('returns active values when is_active is true', () => {
 		const result = resolve_switch_colors(TEST_COLORS, true)
+
 		expect(result.current_color).toBe('#aaa')
 		expect(result.housing_color).toBe('#ccc')
 		expect(result.housing_emissive).toBe(0.4)
@@ -32,6 +33,7 @@ describe('resolve_switch_colors', () => {
 
 	it('returns inactive values when is_active is false', () => {
 		const result = resolve_switch_colors(TEST_COLORS, false)
+
 		expect(result.current_color).toBe('#bbb')
 		expect(result.housing_color).toBe('#ddd')
 		expect(result.housing_emissive).toBe(0.1)
@@ -51,6 +53,7 @@ describe('CYBER_SWITCH_COLORS', () => {
 
 	it('resolves correctly when active', () => {
 		const result = resolve_switch_colors(CYBER_SWITCH_COLORS, true)
+
 		expect(result.current_color).toBe('#ff00ff')
 		expect(result.housing_color).toBe('#120022')
 		expect(result.housing_emissive).toBe(0.4)
@@ -60,6 +63,7 @@ describe('CYBER_SWITCH_COLORS', () => {
 
 	it('resolves correctly when inactive', () => {
 		const result = resolve_switch_colors(CYBER_SWITCH_COLORS, false)
+
 		expect(result.current_color).toBe('#00aaff')
 		expect(result.housing_color).toBe('#001122')
 		expect(result.housing_emissive).toBe(0.15)
@@ -79,6 +83,7 @@ describe('FULLSCREEN_SWITCH_COLORS', () => {
 
 	it('resolves correctly when active', () => {
 		const result = resolve_switch_colors(FULLSCREEN_SWITCH_COLORS, true)
+
 		expect(result.current_color).toBe('#00ff88')
 		expect(result.housing_emissive).toBe(0.4)
 		expect(result.ring_emissive).toBe(4)
@@ -87,6 +92,7 @@ describe('FULLSCREEN_SWITCH_COLORS', () => {
 
 	it('resolves correctly when inactive', () => {
 		const result = resolve_switch_colors(FULLSCREEN_SWITCH_COLORS, false)
+
 		expect(result.current_color).toBe('#006644')
 		expect(result.housing_emissive).toBe(0.05)
 		expect(result.ring_emissive).toBe(0.3)
@@ -105,6 +111,7 @@ describe('FPS_SWITCH_COLORS', () => {
 
 	it('resolves correctly when active', () => {
 		const result = resolve_switch_colors(FPS_SWITCH_COLORS, true)
+
 		expect(result.current_color).toBe('#ffdd00')
 		expect(result.housing_emissive).toBe(0.4)
 		expect(result.ring_emissive).toBe(4)
@@ -113,6 +120,7 @@ describe('FPS_SWITCH_COLORS', () => {
 
 	it('resolves correctly when inactive', () => {
 		const result = resolve_switch_colors(FPS_SWITCH_COLORS, false)
+
 		expect(result.current_color).toBe('#665500')
 		expect(result.housing_emissive).toBe(0.05)
 		expect(result.ring_emissive).toBe(0.3)

--- a/src/lib/game-kit/switch/switch-config.test.ts
+++ b/src/lib/game-kit/switch/switch-config.test.ts
@@ -59,6 +59,7 @@ describe('FPS_SWITCH_Y', () => {
 	it('label clears the top of the CYBER button (no overlap)', () => {
 		const fps_label_y = FPS_SWITCH_Y - LABEL_Y_OFFSET
 		const cyber_top_y = SWITCH_Y + PANEL_HALF
+
 		expect(fps_label_y).toBeGreaterThan(cyber_top_y)
 	})
 })

--- a/src/lib/game-kit/switch/switch-input.test.ts
+++ b/src/lib/game-kit/switch/switch-input.test.ts
@@ -18,12 +18,14 @@ describe('create_switch_input', () => {
 
 	it('does not call action when session is not started', () => {
 		const sw = create_switch_input({ action })
+
 		sw.on_click()
 		expect(action).not.toHaveBeenCalled()
 	})
 
 	it('calls action once session has started', () => {
 		const sw = create_switch_input({ action })
+
 		session.start_session()
 		sw.on_click()
 		expect(action).toHaveBeenCalledTimes(1)
@@ -31,6 +33,7 @@ describe('create_switch_input', () => {
 
 	it('calls action on each click after session started', () => {
 		const sw = create_switch_input({ action })
+
 		session.start_session()
 		sw.on_click()
 		sw.on_click()
@@ -39,6 +42,7 @@ describe('create_switch_input', () => {
 
 	it('plays switch click sound when session is started', () => {
 		const sw = create_switch_input({ action })
+
 		session.start_session()
 		sw.on_click()
 		expect(switch_audio.play_switch_click).toHaveBeenCalledTimes(1)
@@ -46,12 +50,14 @@ describe('create_switch_input', () => {
 
 	it('does not play sound when session is not started', () => {
 		const sw = create_switch_input({ action })
+
 		sw.on_click()
 		expect(switch_audio.play_switch_click).not.toHaveBeenCalled()
 	})
 
 	it('does not call action when guard returns false', () => {
 		const sw = create_switch_input({ action, guard: () => false })
+
 		session.start_session()
 		sw.on_click()
 		expect(action).not.toHaveBeenCalled()
@@ -59,6 +65,7 @@ describe('create_switch_input', () => {
 
 	it('does not play sound when guard returns false', () => {
 		const sw = create_switch_input({ action, guard: () => false })
+
 		session.start_session()
 		sw.on_click()
 		expect(switch_audio.play_switch_click).not.toHaveBeenCalled()
@@ -66,6 +73,7 @@ describe('create_switch_input', () => {
 
 	it('calls action when guard returns true', () => {
 		const sw = create_switch_input({ action, guard: () => true })
+
 		session.start_session()
 		sw.on_click()
 		expect(action).toHaveBeenCalledTimes(1)
@@ -73,6 +81,7 @@ describe('create_switch_input', () => {
 
 	it('calls action when no guard is provided', () => {
 		const sw = create_switch_input({ action })
+
 		session.start_session()
 		sw.on_click()
 		expect(action).toHaveBeenCalledTimes(1)

--- a/src/lib/game-kit/switch/switch-input.ts
+++ b/src/lib/game-kit/switch/switch-input.ts
@@ -10,5 +10,6 @@ export function create_switch_input(config: SwitchInputConfig): { on_click: () =
 		switch_audio.play_switch_click()
 		config.action()
 	}
+
 	return { on_click }
 }

--- a/src/lib/game/Board.svelte
+++ b/src/lib/game/Board.svelte
@@ -104,12 +104,14 @@
 	function get_center_text(): string {
 		if (game_data.phase === 'gameover') return text_gameover.replace(' ', '\n')
 		if (game_data.round > 0) return String(game_data.round)
+
 		return text_start
 	}
 
 	function get_center_base_font_size(): number {
 		if (game_data.phase === 'gameover') return MULTILINE_FONT_SIZE
 		if (game_data.round > 0) return ROUND_DIGIT_FONT_SIZE
+
 		return FONT_SIZE
 	}
 

--- a/src/lib/game/Board.svelte.test.ts
+++ b/src/lib/game/Board.svelte.test.ts
@@ -31,6 +31,7 @@ describe('Board', () => {
 		const { container } = render(Board, {
 			props: { game_data: make_game_data(), ...BOARD_TEXT_PROPS },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -38,6 +39,7 @@ describe('Board', () => {
 		const { container } = render(Board, {
 			props: { game_data: make_game_data({ active_color: 'green' }), ...BOARD_TEXT_PROPS },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -45,6 +47,7 @@ describe('Board', () => {
 		const { container } = render(Board, {
 			props: { game_data: make_game_data({ phase: 'gameover' }), ...BOARD_TEXT_PROPS },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -52,6 +55,7 @@ describe('Board', () => {
 		const { container } = render(Board, {
 			props: { game_data: make_game_data({ phase: 'showing', round: 3 }), ...BOARD_TEXT_PROPS },
 		})
+
 		expect(container).toBeTruthy()
 	})
 
@@ -62,6 +66,7 @@ describe('Board', () => {
 				...BOARD_TEXT_PROPS,
 			},
 		})
+
 		expect(container).toBeTruthy()
 	})
 })
@@ -124,6 +129,7 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 		const fz = BOARD_SOURCE.match(/const\s+FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/u)
 		const ml = BOARD_SOURCE.match(/const\s+MULTILINE_FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/u)
 		const rd = BOARD_SOURCE.match(/const\s+ROUND_DIGIT_FONT_SIZE\s*=\s*(-?\d+(?:\.\d+)?)/u)
+
 		expect(fz).not.toBeNull()
 		expect(ml).not.toBeNull()
 		expect(rd).not.toBeNull()
@@ -161,6 +167,7 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 		// Whitespace-normalized substring check avoids the long chain of `\s*` separators
 		// (SonarCloud rule typescript:S5852 flags such patterns as ReDoS candidates).
 		const normalized = BOARD_SOURCE.replace(/\s+/gu, ' ')
+
 		expect(normalized).toContain(
 			'current_line_height = $derived( is_multiline_center ? MULTILINE_LINE_HEIGHT : SINGLE_LINE_HEIGHT',
 		)

--- a/src/lib/game/Scene.svelte.test.ts
+++ b/src/lib/game/Scene.svelte.test.ts
@@ -55,6 +55,7 @@ vi.mock('$lib/game-kit/scene/room-config', () => ({ ROOM_W: 10, ROOM_D: 10, ROOM
 describe('Scene', () => {
 	it('renders without error', () => {
 		const { container } = render(Scene)
+
 		expect(container).toBeTruthy()
 	})
 

--- a/src/lib/game/audio.svelte.test.ts
+++ b/src/lib/game/audio.svelte.test.ts
@@ -26,6 +26,7 @@ function make_mock_ctx() {
 		destination: {},
 		currentTime: 0,
 	}
+
 	return { ctx, gain_node, osc_node }
 }
 
@@ -60,6 +61,7 @@ describe('game audio envelope', () => {
 
 	it('normal mode uses flat envelope — no exponential ramp', () => {
 		const { ctx, gain_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
@@ -71,6 +73,7 @@ describe('game audio envelope', () => {
 
 	it('cyber mode applies exponential gain ramp', () => {
 		const { ctx, gain_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
@@ -81,6 +84,7 @@ describe('game audio envelope', () => {
 
 	it('play_error_tone uses ERROR_FREQ', () => {
 		const { ctx, osc_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
@@ -91,6 +95,7 @@ describe('game audio envelope', () => {
 
 	it('start_tone starts oscillator without calling stop', () => {
 		const { ctx, osc_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
@@ -102,6 +107,7 @@ describe('game audio envelope', () => {
 
 	it('stop_tone calls stop on the active oscillator', () => {
 		const { ctx, osc_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
@@ -113,6 +119,7 @@ describe('game audio envelope', () => {
 
 	it('play_error_tone normal mode uses flat envelope', () => {
 		const { ctx, gain_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
@@ -124,6 +131,7 @@ describe('game audio envelope', () => {
 
 	it('play_error_tone cyber mode applies exponential gain ramp', () => {
 		const { ctx, gain_node } = make_mock_ctx()
+
 		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 

--- a/src/lib/game/audio.ts
+++ b/src/lib/game/audio.ts
@@ -20,21 +20,25 @@ function create_osc_graph(freq: number, is_alt: boolean): OscGraph | null {
 	if (!ctx) return null
 	const osc = ctx.createOscillator()
 	const gain = ctx.createGain()
+
 	osc.connect(gain)
 	gain.connect(ctx.destination)
 	osc.frequency.setValueAtTime(freq, ctx.currentTime)
 	osc.type = is_alt ? CYBER_WAVE : NORMAL_WAVE
 	gain.gain.setValueAtTime(GAIN_VALUE, ctx.currentTime)
+
 	return { osc, gain, ctx }
 }
 
 function stop_tone(): void {
 	if (!active_osc) return
+
 	try {
 		active_osc.stop()
 	} catch {
 		// already stopped
 	}
+
 	active_osc = null
 }
 

--- a/src/lib/game/credits.test.ts
+++ b/src/lib/game/credits.test.ts
@@ -76,6 +76,7 @@ describe('credits', () => {
 
 		it('includes Special Thanks new contributors after the section header', () => {
 			const special_thanks_block = CREDITS_TEXT.split('SPECIAL THANKS')[1] ?? ''
+
 			expect(special_thanks_block).toContain('Incognito')
 			expect(special_thanks_block).toContain('Daisuke')
 			expect(special_thanks_block).toContain('@akikawa922')
@@ -148,6 +149,7 @@ describe('credits', () => {
 
 		it('matches the number of newlines in CREDITS_TEXT plus one', () => {
 			const line_count_from_text = CREDITS_TEXT.split('\n').length
+
 			expect(CREDITS_LINE_COUNT).toBe(line_count_from_text)
 		})
 	})

--- a/src/lib/game/flash.test.ts
+++ b/src/lib/game/flash.test.ts
@@ -54,6 +54,7 @@ describe('cancel_flash', () => {
 	it('increments flash_gen', () => {
 		const s = make_state()
 		const t = make_timers()
+
 		cancel_flash(s, t)
 		expect(t.flash_gen).toBe(1)
 	})
@@ -61,6 +62,7 @@ describe('cancel_flash', () => {
 	it('clears flash_colors', () => {
 		const s: FlashState = { flash_colors: ['green', 'red'], flash_intensity: 2.5 }
 		const t = make_timers()
+
 		cancel_flash(s, t)
 		expect(s.flash_colors).toHaveLength(0)
 	})
@@ -68,6 +70,7 @@ describe('cancel_flash', () => {
 	it('resets flash_intensity to 1', () => {
 		const s: FlashState = { flash_colors: ['green'], flash_intensity: 2.5 }
 		const t = make_timers()
+
 		cancel_flash(s, t)
 		expect(s.flash_intensity).toBe(1)
 	})
@@ -75,6 +78,7 @@ describe('cancel_flash', () => {
 	it('increments flash_gen each call', () => {
 		const s = make_state()
 		const t = make_timers()
+
 		cancel_flash(s, t)
 		cancel_flash(s, t)
 		expect(t.flash_gen).toBe(2)
@@ -96,6 +100,7 @@ describe('run_victory_flash', () => {
 	it('sets flash_colors to all colors at start of burst', async () => {
 		const s = make_state()
 		const t = make_timers()
+
 		void run_victory_flash(s, t, COLORS, 0)
 		await vi.advanceTimersByTimeAsync(0)
 		expect(s.flash_colors).toEqual(expect.arrayContaining(COLORS))
@@ -104,6 +109,7 @@ describe('run_victory_flash', () => {
 	it('sets flash_intensity above 1 during burst', async () => {
 		const s = make_state()
 		const t = make_timers()
+
 		void run_victory_flash(s, t, COLORS, 0)
 		await vi.advanceTimersByTimeAsync(0)
 		expect(s.flash_intensity).toBeGreaterThan(1)
@@ -113,6 +119,7 @@ describe('run_victory_flash', () => {
 		const spy = vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {})
 		const s = make_state()
 		const t = make_timers()
+
 		void run_victory_flash(s, t, COLORS, 0)
 		await vi.advanceTimersByTimeAsync(FLASH_BURST_ON_MS)
 		const called_colors = spy.mock.calls.map((c) => c[0])
@@ -122,12 +129,15 @@ describe('run_victory_flash', () => {
 	it('aborts when flash_gen changes mid-run', async () => {
 		const s = make_state()
 		const t = make_timers()
+
 		void run_victory_flash(s, t, COLORS, 0)
 		await vi.advanceTimersByTimeAsync(0)
 		cancel_flash(s, t)
 		const calls_before = vi.mocked(game_audio.play_tone).mock.calls.length
+
 		await vi.runAllTimersAsync()
 		const calls_after = vi.mocked(game_audio.play_tone).mock.calls.length
+
 		expect(calls_after).toBe(calls_before)
 	})
 
@@ -138,6 +148,7 @@ describe('run_victory_flash', () => {
 			FLASH_BURST_CYCLES * (FLASH_BURST_ON_MS + FLASH_BURST_OFF_MS) +
 			COLORS.length * (FLASH_CASCADE_FWD_MS + FLASH_CASCADE_REV_MS) +
 			FLASH_FINALE_MS
+
 		void run_victory_flash(s, t, COLORS, 0)
 		await vi.advanceTimersByTimeAsync(flash_total_ms + 10)
 		expect(s.flash_colors).toHaveLength(0)
@@ -149,9 +160,11 @@ describe('run_victory_flash', () => {
 		const spy = vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {})
 		const s = make_state()
 		const t = make_timers()
+
 		void run_victory_flash(s, t, custom, 0)
 		await vi.advanceTimersByTimeAsync(FLASH_BURST_ON_MS)
 		const called_colors = spy.mock.calls.map((c) => c[0])
+
 		expect(called_colors).toContain('green')
 		expect(called_colors).toContain('blue')
 	})

--- a/src/lib/game/flash.ts
+++ b/src/lib/game/flash.ts
@@ -69,6 +69,7 @@ async function flash_cascade(
 		game_audio.play_tone(color, FLASH_CASCADE_FWD_MS, game_state.is_alt)
 		await delay(FLASH_CASCADE_FWD_MS)
 	}
+
 	for (const color of [...colors].reverse()) {
 		if (t.flash_gen !== gen) return
 		s.flash_colors = [color]

--- a/src/lib/game/game.svelte.test.ts
+++ b/src/lib/game/game.svelte.test.ts
@@ -32,6 +32,7 @@ function wrong_color(color: ButtonColor): ButtonColor {
 function seq_at(i: number): ButtonColor {
 	const color = game.sequence[i]
 	if (!color) throw new Error(`sequence index ${String(i)} out of range`)
+
 	return color
 }
 
@@ -98,6 +99,7 @@ describe('game FSM', () => {
 		game.start()
 		await vi.runAllTimersAsync()
 		const final_color = seq_at(0)
+
 		game.press(final_color)
 		await vi.advanceTimersByTimeAsync(RESTART_DELAY_MS * 2)
 		expect(game.phase).toBe('player_input')
@@ -121,6 +123,7 @@ describe('game FSM', () => {
 		await vi.runAllTimersAsync()
 		game.press(seq_at(0))
 		const spy = vi.spyOn(game_audio, 'start_tone')
+
 		game.press('green')
 		game.press('red')
 		expect(spy).not.toHaveBeenCalled()
@@ -155,6 +158,7 @@ describe('game FSM', () => {
 		game.release()
 		await vi.runAllTimersAsync() // drain round 2 show
 		const first_color = seq_at(0)
+
 		game.press(first_color) // first of two correct presses
 		game.release()
 		expect(game.position).toBe(1)
@@ -172,6 +176,7 @@ describe('game FSM', () => {
 
 	it('wrong press + release plays error tone for ERROR_BEEP_MS', async () => {
 		const spy = vi.spyOn(game_audio, 'play_error_tone')
+
 		game.start()
 		await vi.runAllTimersAsync()
 		game.press(wrong_color(seq_at(0)))
@@ -189,6 +194,7 @@ describe('game FSM', () => {
 		game.start()
 		await vi.runAllTimersAsync()
 		const color = seq_at(0)
+
 		game.press(color)
 		expect(game.pressed_color).toBe(color)
 		await vi.advanceTimersByTimeAsync(TONE_MS + 10)
@@ -219,6 +225,7 @@ describe('game FSM', () => {
 		game.start()
 		await vi.runAllTimersAsync()
 		const wrong = wrong_color(seq_at(0))
+
 		game.press(wrong)
 		expect(game.pressed_color).toBe(wrong)
 		game.reset()
@@ -270,9 +277,11 @@ describe('game FSM', () => {
 
 	it('press() starts tone for pressed color', async () => {
 		const spy = vi.spyOn(game_audio, 'start_tone')
+
 		game.start()
 		await vi.runAllTimersAsync()
 		const color = seq_at(0)
+
 		game.press(color)
 		expect(spy).toHaveBeenCalledWith(color, false)
 	})
@@ -280,12 +289,14 @@ describe('game FSM', () => {
 	it('press() does not start tone when not in player_input phase', () => {
 		game.start() // phase = showing
 		const spy = vi.spyOn(game_audio, 'start_tone')
+
 		game.press('green')
 		expect(spy).not.toHaveBeenCalled()
 	})
 
 	it('release() stops the tone', async () => {
 		const spy = vi.spyOn(game_audio, 'stop_tone')
+
 		game.start()
 		await vi.runAllTimersAsync()
 		game.press(seq_at(0))
@@ -386,12 +397,14 @@ describe('victory flash', () => {
 
 	it('play_tone is called for all colors during burst stage', async () => {
 		const spy = vi.spyOn(game_audio, 'play_tone')
+
 		game.start()
 		await vi.runAllTimersAsync()
 		spy.mockClear()
 		game.press(seq_at(0))
 		game.release()
 		const called_colors = spy.mock.calls.map((c) => c[0])
+
 		expect(called_colors).toContain('green')
 		expect(called_colors).toContain('red')
 		expect(called_colors).toContain('yellow')
@@ -403,6 +416,7 @@ describe('victory flash', () => {
 			FLASH_BURST_CYCLES * (FLASH_BURST_ON_MS + FLASH_BURST_OFF_MS) +
 			ALL_COLORS.length * (FLASH_CASCADE_FWD_MS + FLASH_CASCADE_REV_MS) +
 			FLASH_FINALE_MS
+
 		game.start()
 		await vi.runAllTimersAsync()
 		game.press(seq_at(0))
@@ -451,6 +465,7 @@ describe('create_game isolation', () => {
 		const score_b = create_score()
 		const a = create_game(score_a)
 		const b = create_game(score_b)
+
 		a.start()
 		expect(a.phase).toBe('showing')
 		expect(b.phase).toBe('idle')
@@ -462,6 +477,7 @@ describe('create_game isolation', () => {
 		const score_b = create_score()
 		const a = create_game(score_a)
 		const b = create_game(score_b)
+
 		a.start()
 		expect(a.sequence).toHaveLength(1)
 		expect(b.sequence).toHaveLength(0)
@@ -472,11 +488,14 @@ describe('create_game isolation', () => {
 		const score_c = create_score()
 		const custom_colors: Array<ButtonColor> = ['green', 'blue']
 		const c = create_game(score_c, { colors: custom_colors })
+
 		c.start()
+
 		for (let i = 0; i < 20; i++) {
 			c.reset()
 			c.start()
 		}
+
 		const used = new Set(c.sequence)
 		for (const color of used) expect(custom_colors).toContain(color)
 		c.reset()

--- a/src/lib/game/game.svelte.ts
+++ b/src/lib/game/game.svelte.ts
@@ -39,11 +39,13 @@ function get_step_ms(len: number): number {
 	if (len <= 5) return STEP_MS_1_5
 	if (len <= 13) return STEP_MS_6_13
 	if (len <= 20) return STEP_MS_14_20
+
 	return STEP_MS_21_PLUS
 }
 
 function add_to_sequence(s: GameState, colors: ReadonlyArray<ButtonColor>): void {
 	const index = Math.floor(Math.random() * colors.length) // NOSONAR — game RNG, not security-sensitive
+
 	s.sequence.push(colors[index] ?? FALLBACK_COLOR)
 }
 
@@ -56,6 +58,7 @@ async function run_show(s: GameState, t: GameTimers, gen: number): Promise<void>
 	const step_ms = get_step_ms(s.sequence.length)
 	const on_ms = step_ms * ON_RATIO
 	const off_ms = step_ms * OFF_RATIO
+
 	for (const color of s.sequence) {
 		if (gen !== t.show_gen) return
 		s.active_color = color
@@ -65,6 +68,7 @@ async function run_show(s: GameState, t: GameTimers, gen: number): Promise<void>
 		s.active_color = null
 		await delay(off_ms)
 	}
+
 	if (gen !== t.show_gen) return
 	t.input_start_ms = Date.now()
 	s.phase = 'player_input'
@@ -130,9 +134,11 @@ function release_game(
 ): void {
 	game_audio.stop_tone()
 	const color = s.pressed_color
+
 	s.pressed_color = null
 	if (s.phase !== 'player_input') return
 	if (color === null) return
+
 	if (color === s.sequence[s.position]) {
 		handle_correct_release(s, t, score, colors)
 	} else {
@@ -224,6 +230,7 @@ export function create_game(score: ScoreInstance, config: GameConfig = {}) {
 		flash_intensity: 1,
 	})
 	const t: GameTimers = { show_gen: 0, flash_gen: 0, restart_timer: null, input_start_ms: 0 }
+
 	return make_game_api(s, t, score, colors)
 }
 

--- a/src/lib/game/score.svelte.test.ts
+++ b/src/lib/game/score.svelte.test.ts
@@ -35,6 +35,7 @@ describe('score', () => {
 		it('decays by 0.1 per avg second per button', () => {
 			const avg_s = ELAPSED_5S / 1000 / SEQ_5
 			const expected = 1 - avg_s * 0.1
+
 			expect(score.calculate_time_coefficient(ELAPSED_5S, SEQ_5)).toBeCloseTo(expected, 5)
 		})
 
@@ -45,6 +46,7 @@ describe('score', () => {
 		it('normalizes by sequence length so longer rounds are not unfairly penalized', () => {
 			const coeff_short = score.calculate_time_coefficient(ELAPSED_5S, SEQ_1)
 			const coeff_long = score.calculate_time_coefficient(ELAPSED_5S * SEQ_5, SEQ_5)
+
 			expect(coeff_short).toBeCloseTo(coeff_long, 5)
 		})
 	})
@@ -58,17 +60,20 @@ describe('score', () => {
 		it('scales with round number', () => {
 			const r1 = score.calculate_round_score(ELAPSED_0, ROUND_1, ROUND_1)
 			const r5 = score.calculate_round_score(ELAPSED_0, ROUND_5, ROUND_5)
+
 			expect(r5).toBe(r1 * ROUND_5)
 		})
 
 		it('produces a lower score for slower responses', () => {
 			const fast = score.calculate_round_score(ELAPSED_0, SEQ_1, ROUND_1)
 			const slow = score.calculate_round_score(ELAPSED_10S, SEQ_1, ROUND_1)
+
 			expect(slow).toBeLessThan(fast)
 		})
 
 		it('floors at 10% of BASE_SCORE * round for very slow responses', () => {
 			const floor_score = score.calculate_round_score(ELAPSED_100S, SEQ_1, ROUND_5)
+
 			expect(floor_score).toBe(500)
 		})
 	})
@@ -101,6 +106,7 @@ describe('score', () => {
 
 		it('updates high_score when current_score exceeds it', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			expect(score.high_score).toBeGreaterThan(prev_high)
 			expect(score.high_score).toBe(score.current_score)
@@ -108,8 +114,10 @@ describe('score', () => {
 
 		it('does not update high_score when current_score stays below it', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			const established = score.high_score
+
 			score.reset()
 			score.add_round_score(ELAPSED_100S, SEQ_1, ROUND_1)
 			expect(score.high_score).toBe(established)
@@ -118,6 +126,7 @@ describe('score', () => {
 		it('sets is_new_high_score to true when current_score exceeds high_score', () => {
 			expect(score.is_new_high_score).toBe(false)
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			expect(score.is_new_high_score).toBe(true)
 		})
@@ -132,6 +141,7 @@ describe('score', () => {
 
 		it('resets is_new_high_score to false', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			expect(score.is_new_high_score).toBe(true)
 			score.reset()
@@ -140,8 +150,10 @@ describe('score', () => {
 
 		it('preserves high_score across reset', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			const new_high = score.high_score
+
 			score.reset()
 			expect(score.high_score).toBe(new_high)
 		})
@@ -167,22 +179,27 @@ describe('score', () => {
 	describe('high_score_round', () => {
 		it('is updated to the round when a new high score is set', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			expect(score.high_score_round).toBe(prev_high + 2)
 		})
 
 		it('is preserved across reset', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 2)
 			const expected_round = prev_high + 2
+
 			score.reset()
 			expect(score.high_score_round).toBe(expected_round)
 		})
 
 		it('is not updated when current score stays below high score', () => {
 			const prev_high = score.high_score
+
 			score.add_round_score(ELAPSED_0, SEQ_1, prev_high + 5)
 			const saved_round = score.high_score_round
+
 			score.reset()
 			score.add_round_score(ELAPSED_100S, SEQ_1, ROUND_1)
 			expect(score.high_score_round).toBe(saved_round)
@@ -222,11 +239,13 @@ describe('load_stored_data', () => {
 		const stored_score = 5000
 		const stored_round = 3
 		const stored_check = compute_check(stored_score, stored_round)
+
 		vi.stubGlobal('localStorage', {
 			getItem: (key: string) => {
 				if (key === DEFAULT_KEYS.score) return String(stored_score)
 				if (key === DEFAULT_KEYS.round) return String(stored_round)
 				if (key === DEFAULT_KEYS.check) return String(stored_check)
+
 				return null
 			},
 			setItem: () => {},
@@ -240,6 +259,7 @@ describe('load_stored_data', () => {
 				if (key === DEFAULT_KEYS.score) return '5000'
 				if (key === DEFAULT_KEYS.round) return '3'
 				if (key === DEFAULT_KEYS.check) return '99999'
+
 				return null
 			},
 			setItem: () => {},
@@ -261,11 +281,13 @@ describe('load_stored_data', () => {
 		const stored_score = 1000
 		const stored_round = 1
 		const stored_check = compute_check(stored_score, stored_round)
+
 		vi.stubGlobal('localStorage', {
 			getItem: (key: string) => {
 				if (key === custom_keys.score) return String(stored_score)
 				if (key === custom_keys.round) return String(stored_round)
 				if (key === custom_keys.check) return String(stored_check)
+
 				return null
 			},
 			setItem: () => {},
@@ -278,6 +300,7 @@ describe('create_score isolation', () => {
 	it('two instances do not share current_score state', () => {
 		const a = create_score()
 		const b = create_score()
+
 		a.add_round_score(ELAPSED_0, SEQ_1, ROUND_1)
 		expect(a.current_score).toBeGreaterThan(0)
 		expect(b.current_score).toBe(0)
@@ -285,6 +308,7 @@ describe('create_score isolation', () => {
 
 	it('custom key prefix stores to different keys than default', () => {
 		const custom = create_score('test')
+
 		vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {} })
 		expect(custom.high_score).toBe(0)
 		vi.unstubAllGlobals()
@@ -311,6 +335,7 @@ describe('legacy simon_* migration', () => {
 
 	function stub_legacy_only(store: Record<string, string>): { set_calls: Array<[string, string]> } {
 		const set_calls: Array<[string, string]> = []
+
 		vi.stubGlobal('localStorage', {
 			getItem: (key: string) => store[key] ?? null,
 			setItem: (key: string, value: string) => {
@@ -318,17 +343,20 @@ describe('legacy simon_* migration', () => {
 				store[key] = value
 			},
 		})
+
 		return { set_calls }
 	}
 
 	it('loads legacy simon_* scores when new game_* keys are empty', () => {
 		const legacy_check = compute_check(LEGACY_SCORE, LEGACY_ROUND)
+
 		stub_legacy_only({
 			[LEGACY_KEYS.score]: String(LEGACY_SCORE),
 			[LEGACY_KEYS.round]: String(LEGACY_ROUND),
 			[LEGACY_KEYS.check]: String(legacy_check),
 		})
 		const migrated = create_score()
+
 		expect(migrated.high_score).toBe(LEGACY_SCORE)
 		expect(migrated.high_score_round).toBe(LEGACY_ROUND)
 	})
@@ -340,8 +368,10 @@ describe('legacy simon_* migration', () => {
 			[LEGACY_KEYS.round]: String(LEGACY_ROUND),
 			[LEGACY_KEYS.check]: String(legacy_check),
 		})
+
 		create_score()
 		const written_keys = new Set(set_calls.map(([key]) => key))
+
 		expect(written_keys.has(NEW_KEYS.score)).toBe(true)
 		expect(written_keys.has(NEW_KEYS.round)).toBe(true)
 		expect(written_keys.has(NEW_KEYS.check)).toBe(true)
@@ -352,6 +382,7 @@ describe('legacy simon_* migration', () => {
 		const new_round = 3
 		const new_check = compute_check(new_score, new_round)
 		const legacy_check = compute_check(LEGACY_SCORE, LEGACY_ROUND)
+
 		stub_legacy_only({
 			[NEW_KEYS.score]: String(new_score),
 			[NEW_KEYS.round]: String(new_round),
@@ -361,6 +392,7 @@ describe('legacy simon_* migration', () => {
 			[LEGACY_KEYS.check]: String(legacy_check),
 		})
 		const fresh = create_score()
+
 		expect(fresh.high_score).toBe(new_score)
 		expect(fresh.high_score_round).toBe(new_round)
 	})
@@ -373,6 +405,7 @@ describe('legacy simon_* migration', () => {
 			[LEGACY_KEYS.check]: String(legacy_check),
 		})
 		const custom = create_score('test')
+
 		expect(custom.high_score).toBe(0)
 		expect(set_calls).toHaveLength(0)
 	})

--- a/src/lib/game/score.svelte.ts
+++ b/src/lib/game/score.svelte.ts
@@ -18,6 +18,7 @@ function make_storage_keys(prefix: string): StorageKeys {
 		check: `${prefix}_high_score_check`,
 	}
 }
+
 type RoundData = { elapsed_ms: number; sequence_length: number; round: number }
 
 export function compute_check(value: number, round: number): number {
@@ -33,6 +34,7 @@ export function load_stored_data(keys: StorageKeys): { score: number; round: num
 		const is_valid_round = Number.isFinite(stored_round) && stored_round >= 0
 		const is_check_ok = compute_check(stored_score, stored_round) === stored_check
 		if (!is_valid_score || !is_valid_round || !is_check_ok) return { score: 0, round: 0 }
+
 		return { score: stored_score, round: stored_round }
 	} catch {
 		return { score: 0, round: 0 }
@@ -51,6 +53,7 @@ function save_high_score(value: number, round: number, keys: StorageKeys): void 
 
 export function calculate_time_coefficient(elapsed_ms: number, sequence_length: number): number {
 	const avg_s = elapsed_ms / 1000 / sequence_length
+
 	return Math.max(MIN_TIME_COEFF, 1 - avg_s * TIME_COEFF_DECAY)
 }
 
@@ -128,15 +131,18 @@ function migrate_legacy_score(keys: StorageKeys): { score: number; round: number
 	const legacy = load_stored_data(legacy_keys)
 	if (legacy.score === 0 && legacy.round === 0) return legacy
 	save_high_score(legacy.score, legacy.round, keys)
+
 	return legacy
 }
 
 export function create_score(key_prefix: string = GAME_SCORE_KEY_PREFIX) {
 	const keys = make_storage_keys(key_prefix)
 	let loaded = load_stored_data(keys)
+
 	if (key_prefix === GAME_SCORE_KEY_PREFIX && loaded.score === 0 && loaded.round === 0) {
 		loaded = migrate_legacy_score(keys)
 	}
+
 	const s = $state<ScoreState>({
 		current_score: 0,
 		high_score: loaded.score,
@@ -144,6 +150,7 @@ export function create_score(key_prefix: string = GAME_SCORE_KEY_PREFIX) {
 		is_new_high_score: false,
 		last_cleared_round: 0,
 	})
+
 	return make_score_api(s, keys)
 }
 

--- a/src/lib/game/types.test.ts
+++ b/src/lib/game/types.test.ts
@@ -21,6 +21,7 @@ describe('game types', () => {
 			flash_colors: [],
 			flash_intensity: 1,
 		}
+
 		expect(data.phase).toBe('idle')
 		expect(data.pressed_color).toBe('green')
 	})

--- a/src/routes/e2e-helpers.ts
+++ b/src/routes/e2e-helpers.ts
@@ -6,6 +6,7 @@ export async function stub_touch_primary(page: Page, is_touch: boolean): Promise
 	await page.addInitScript(
 		([query, matches]) => {
 			const original = globalThis.matchMedia.bind(globalThis)
+
 			globalThis.matchMedia = function patched(input: string): MediaQueryList {
 				if (input === query) {
 					return {
@@ -21,6 +22,7 @@ export async function stub_touch_primary(page: Page, is_touch: boolean): Promise
 						},
 					} as MediaQueryList
 				}
+
 				return original(input)
 			}
 		},

--- a/src/routes/page-features.e2e.ts
+++ b/src/routes/page-features.e2e.ts
@@ -22,14 +22,19 @@ test('fullscreen is requested on touch-primary devices when start hint is clicke
 		() =>
 			new Promise<string>((resolve) => {
 				const scene = document.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 				if (!scene) {
 					resolve('no-scene')
+
 					return
 				}
+
 				scene.requestFullscreen = function (): Promise<void> {
 					resolve('game-scene')
+
 					return Promise.resolve()
 				}
+
 				scene.click()
 			}),
 	)
@@ -48,15 +53,21 @@ test('fullscreen is NOT requested on desktop devices when start hint is clicked'
 		(wait_ms) =>
 			new Promise<boolean>((resolve) => {
 				const scene = document.querySelector<HTMLElement>('[data-testid="game-scene"]')
+
 				if (!scene) {
 					resolve(false)
+
 					return
 				}
+
 				let called = false
+
 				scene.requestFullscreen = function (): Promise<void> {
 					called = true
+
 					return Promise.resolve()
 				}
+
 				scene.click()
 				setTimeout(() => resolve(called), wait_ms)
 			}),
@@ -93,6 +104,7 @@ test('page has no critical or serious accessibility violations', async ({ page }
 	const violations = results.violations.filter(
 		(v) => v.impact === 'critical' || v.impact === 'serious',
 	)
+
 	expect(violations).toHaveLength(0)
 })
 
@@ -101,6 +113,7 @@ test('high score persists in localStorage across page reload', async ({ page }) 
 		(Math.imul(SAMPLE_HIGH_SCORE + 1, CHECK_SEED) ^
 			Math.imul(SAMPLE_HIGH_ROUND + 1, CHECK_SEED >>> 1)) >>>
 		0
+
 	await page.goto('/')
 	await page.evaluate(
 		([sk, rk, ck, score, round, check]) => {
@@ -126,6 +139,7 @@ test('high score persists in localStorage across page reload', async ({ page }) 
 		],
 		[HIGH_SCORE_STORAGE_KEY, HIGH_SCORE_ROUND_KEY, HIGH_SCORE_CHECK_KEY] as const,
 	)
+
 	expect(score_val).toBe(String(SAMPLE_HIGH_SCORE))
 	expect(round_val).toBe(String(SAMPLE_HIGH_ROUND))
 	expect(check_val).toBe(String(stored_check))
@@ -133,6 +147,7 @@ test('high score persists in localStorage across page reload', async ({ page }) 
 
 test('game scene loads without shadow-related WebGL errors', async ({ page }) => {
 	const errors: Array<string> = []
+
 	page.on('pageerror', (err) => errors.push(err.message))
 	await page.goto('/')
 	await expect(page.locator('[data-testid="loading-overlay"]')).toBeHidden({
@@ -141,6 +156,7 @@ test('game scene loads without shadow-related WebGL errors', async ({ page }) =>
 	const webgl_errors = errors.filter(
 		(e) => e.toLowerCase().includes('shadow') || e.toLowerCase().includes('webgl'),
 	)
+
 	expect(webgl_errors).toHaveLength(0)
 })
 
@@ -149,8 +165,10 @@ test('favicon link points to the game icon, not the Svelte logo', async ({ page 
 	const icon_href = await page.evaluate(() => {
 		const links = document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]')
 		const last = links[links.length - 1]
+
 		return last?.getAttribute('href') ?? null
 	})
+
 	expect(icon_href).toBe('/icon.svg')
 })
 
@@ -159,14 +177,17 @@ test('loading overlay shows JOSHUA GAME as the game title', async ({ page }) => 
 	const game_title = await page.evaluate(() => {
 		const overlay = document.getElementById('static-loading-overlay')
 		const el = overlay?.querySelector('.game-title')
+
 		return el?.textContent ?? null
 	})
+
 	expect(game_title).toBe('JOSHUA GAME')
 })
 
 test('server HTML has game name placeholders replaced', async ({ page }) => {
 	const response = await page.request.get('/')
 	const html = await response.text()
+
 	expect(html).toContain('<title>Joshua Game</title>')
 	expect(html).toContain('>JOSHUA GAME<')
 	expect(html).not.toContain('__GAME_NAME__')
@@ -177,8 +198,10 @@ test('PWA manifest is linked in document head', async ({ page }) => {
 	await page.goto('/')
 	const manifest_href = await page.evaluate(() => {
 		const link = document.querySelector<HTMLLinkElement>('link[rel="manifest"]')
+
 		return link?.href ?? null
 	})
+
 	expect(manifest_href).not.toBeNull()
 })
 
@@ -187,7 +210,9 @@ test('service worker is ready after page load', async ({ page }) => {
 	const scope = await page.evaluate(async () => {
 		if (!('serviceWorker' in navigator)) return null
 		const reg = await navigator.serviceWorker.ready
+
 		return reg.scope
 	})
+
 	expect(scope).toBeTruthy()
 })

--- a/src/routes/page.e2e.ts
+++ b/src/routes/page.e2e.ts
@@ -11,6 +11,7 @@ const READY_PROGRESS_VALUE = 100
 test('page response includes HTTP security headers', async ({ page }) => {
 	const response = await page.goto('/')
 	const headers = response?.headers() ?? {}
+
 	expect(headers['x-frame-options']).toBe('SAMEORIGIN')
 	expect(headers['x-content-type-options']).toBe('nosniff')
 	expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin')
@@ -91,8 +92,10 @@ test('first click on the game scene does not toggle cyber mode (cyber-glow stays
 	await expect(page.locator('[data-testid="game-scene"]')).toBeVisible()
 	const glow_locator = page.locator('[data-testid="cyber-glow"]')
 	const initial_glow_count = await glow_locator.count()
+
 	await page.locator('[data-testid="game-scene"]').click()
 	const after_glow_count = await glow_locator.count()
+
 	expect(after_glow_count).toBe(initial_glow_count)
 })
 

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -14,12 +14,14 @@ describe('Home page', () => {
 
 	it('does not render cyber-glow in normal mode', () => {
 		const { container } = render(Page)
+
 		expect(container.querySelector('[data-testid="cyber-glow"]')).toBeNull()
 	})
 
 	it('renders cyber-glow when cyber mode is active', () => {
 		game_state.toggle_alt()
 		const { container } = render(Page)
+
 		expect(container.querySelector('[data-testid="cyber-glow"]')).toBeTruthy()
 	})
 })


### PR DESCRIPTION
## Scope

**PR-5 of multi-PR migration** addressing #188 (continues PR-4 #193).

Removes both `'padding-line-between-statements': 'off'` AND `'@stylistic/padding-line-between-statements': 'off'` from the [eslint.config.js](eslint.config.js) backlog. All 714 violations were auto-fixed by `eslint --fix` — pure blank-line formatting across 99 files.

## Verification

- 714/714 violations resolved
- All 1065 unit tests pass unchanged (formatting only — no semantics changed)
- tsc + cspell green
- Diff: 99 files, 722 insertions / 5 deletions — all blank-line additions/removals
- Highest-volume rule in the backlog; biggest single mechanical PR of the series

This PR partially addresses **#188**; **#188 stays open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)