### PR TITLE
PR-6 of strict eslint migration: batch-enable 22 safe auto-fixable rules #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -115,66 +115,19 @@ const PR1_TEMPORARY_RULE_DISABLES = {
 	'unicorn/no-array-reverse': 'off',
 	// TODO #188 follow-up: tighten unknown-type return sites
 	'@typescript-eslint/no-unsafe-return': 'off',
-	// TODO #188 follow-up: convert `let` to `const` where never reassigned
-	'prefer-const': 'off',
-	// TODO #188 follow-up: simplify regex literals to their canonical form
-	'unicorn/better-regex': 'off',
 	// TODO #188 follow-up: prefer RegExp.exec over String.match where suitable
 	'@typescript-eslint/prefer-regexp-exec': 'off',
-	// TODO #188 follow-up: prefer spread over Array.from / apply
-	'unicorn/prefer-spread': 'off',
 	// TODO #188 follow-up: mark promise-returning functions explicitly async
 	'@typescript-eslint/promise-function-async': 'off',
-	// TODO #188 follow-up: use String.raw for backslash-heavy literals
-	'unicorn/prefer-string-raw': 'off',
-	// TODO #188 follow-up: use === -1 / !== -1 consistently for indexOf checks
-	'unicorn/consistent-existence-index-check': 'off',
-	// TODO #188 follow-up: prefer Element.append over Element.appendChild
-	'unicorn/prefer-dom-node-append': 'off',
-	// TODO #188 follow-up: drop unnecessary type assertions
-	'@typescript-eslint/no-unnecessary-type-assertion': 'off',
-	// TODO #188 follow-up: prefer arrow callbacks where `this` binding is not needed
+	// PR-6 left these specific rules disabled: they auto-fix in dangerous ways verified earlier in this series.
+	// TODO #188 follow-up: `prefer-arrow-callback` rewrites `function () {}` to `() => {}` which breaks `new`-constructibility (Audio mock regression seen in pre-merge baseline)
 	'prefer-arrow-callback': 'off',
-	// TODO #188 follow-up: drop zero fractions (`1.0` → `1`)
-	'unicorn/no-zero-fractions': 'off',
-	// TODO #188 follow-up: drop redundant `undefined` arguments / values
+	// TODO #188 follow-up: `unicorn/no-useless-undefined` strips required-by-signature undefined args (broke vi.stubGlobal / mockResolvedValue calls in pre-merge baseline)
 	'unicorn/no-useless-undefined': 'off',
-	// TODO #188 follow-up: add braces to single-statement if/for/while
-	curly: 'off',
-	// TODO #188 follow-up: prefer Array#for-of over Array#forEach
-	'unicorn/no-array-for-each': 'off',
-	// TODO #188 follow-up: drop inferrable type annotations
-	'@typescript-eslint/no-inferrable-types': 'off',
-	// TODO #188 follow-up: prefer property access over bracket access for valid identifiers
+	// TODO #188 follow-up: `dot-notation` converts bracket-access to dot-access, but TS index-signature types REQUIRE bracket access (broke u_res access in crt-dither test in pre-merge baseline)
 	'dot-notation': 'off',
-	// TODO #188 follow-up: use Number.* instead of global parseInt / isNaN
-	'unicorn/prefer-number-properties': 'off',
-	// TODO #188 follow-up: add blank lines between class members
-	'lines-between-class-members': 'off',
-	// TODO #188 follow-up: lowercase hex literals consistently
+	// TODO #188 follow-up: `unicorn/number-literal-case` wants uppercase hex digits (0x9E) but prettier normalizes them to lowercase (0x9e), creating an unresolvable lint↔format conflict. Configure prettier or move the hex literal to a non-formatted location to re-enable.
 	'unicorn/number-literal-case': 'off',
-	// TODO #188 follow-up: consolidate import specifiers per module
-	'unicorn/require-module-specifiers': 'off',
-	// TODO #188 follow-up: prefer `import type` for type-only imports
-	'@typescript-eslint/consistent-type-imports': 'off',
-	// TODO #188 follow-up: use `globalThis` instead of `window` / `self`
-	'unicorn/prefer-global-this': 'off',
-	// TODO #188 follow-up: use Math.* modern APIs (e.g. Math.cbrt, Math.log2)
-	'unicorn/prefer-modern-math-apis': 'off',
-	// TODO #188 follow-up: use `**` operator instead of Math.pow
-	'prefer-exponentiation-operator': 'off',
-	// TODO #188 follow-up: prefer switch over long if/else chains
-	'unicorn/prefer-switch': 'off',
-	// TODO #188 follow-up: standardize method-signature shorthand vs property style
-	'@typescript-eslint/method-signature-style': 'off',
-	// TODO #188 follow-up: drop redundant default-assignment patterns
-	'@typescript-eslint/no-useless-default-assignment': 'off',
-	// TODO #188 follow-up: prefer String#replaceAll over String#replace with /g
-	'unicorn/prefer-string-replace-all': 'off',
-	// TODO #188 follow-up: prefer template literals over string concatenation
-	'prefer-template': 'off',
-	// TODO #188 follow-up: prefer Array#at over [length - 1]
-	'unicorn/prefer-at': 'off',
 }
 
 // `scripts/` and `templates/` are not included in any tsconfig project here:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.82.0",
+	"version": "0.83.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -9,5 +9,3 @@ declare global {
 		// interface Platform {}
 	}
 }
-
-export {}

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -18,7 +18,7 @@
 		aria_label?: string
 	}
 
-	let { size = DEFAULT_SIZE, aria_label = DEFAULT_ARIA_LABEL }: Props = $props()
+	const { size = DEFAULT_SIZE, aria_label = DEFAULT_ARIA_LABEL }: Props = $props()
 	const filter_id = generate_filter_id()
 </script>
 

--- a/src/lib/game-kit/CrtChromaticFilter.svelte.test.ts
+++ b/src/lib/game-kit/CrtChromaticFilter.svelte.test.ts
@@ -45,8 +45,8 @@ describe('CrtChromaticFilter.svelte — SVG defs structure', () => {
 		expect(r_dx_str).toBeDefined()
 		expect(b_dx_str).toBeDefined()
 		if (r_dx_str === undefined || b_dx_str === undefined) return
-		const r_dx = parseFloat(r_dx_str)
-		const b_dx = parseFloat(b_dx_str)
+		const r_dx = Number.parseFloat(r_dx_str)
+		const b_dx = Number.parseFloat(b_dx_str)
 
 		expect(r_dx).not.toBe(0)
 		expect(r_dx).toBe(-b_dx)

--- a/src/lib/game-kit/CrtDitherPass.svelte
+++ b/src/lib/game-kit/CrtDitherPass.svelte
@@ -23,7 +23,7 @@
 	} from '$lib/game-kit/crt-dither'
 	import { crt } from '$lib/game-kit/crt.svelte'
 	import { onDestroy } from 'svelte'
-	import { NearestFilter, ShaderMaterial, Texture, Vector2, Vector3 } from 'three'
+	import { NearestFilter, ShaderMaterial, Vector2, Vector3, type Texture } from 'three'
 	import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js'
 	import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js'
 	import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
@@ -32,7 +32,7 @@
 	interface Props {
 		lo_dpr: number
 	}
-	let { lo_dpr }: Props = $props()
+	const { lo_dpr }: Props = $props()
 
 	const ctx = useThrelte()
 

--- a/src/lib/game-kit/GameScene.svelte
+++ b/src/lib/game-kit/GameScene.svelte
@@ -52,7 +52,7 @@
 		label_pause: string
 	}
 
-	let {
+	const {
 		children,
 		hint_text = '',
 		on_start,
@@ -65,7 +65,7 @@
 	let container: HTMLElement
 	let container_width = $state(0)
 	let container_height = $state(0)
-	let pixel_dpr = $derived(
+	const pixel_dpr = $derived(
 		compute_pixel_dpr(
 			container_width,
 			container_height,
@@ -78,22 +78,22 @@
 	// lo_dpr is the low-res rendering scale passed to CrtDitherPass for Stage 1
 	// (game scene + dither). The canvas itself runs at dpr=1 so Stage 2 (scanlines
 	// + barrel) can operate at full CSS resolution for smooth CRT curves.
-	let lo_dpr = $derived(pixel_dpr)
-	let is_dragging_look = $derived(input.is_dragging_look)
-	let drag_start_x = $derived(input.drag_start_x)
-	let drag_start_y = $derived(input.drag_start_y)
-	let is_pseudo_fullscreen = $derived(fullscreen.is_pseudo_fullscreen)
-	let is_fullscreen_active = $derived(fullscreen.is_active)
-	let is_started = $derived(session.is_session_started)
-	let is_touch = $derived(device.is_touch_primary)
-	let game_status = $derived(is_started ? label_game_started : '')
-	let is_alt = $derived(game_state.is_alt)
-	let is_crt_enabled = $derived(crt.is_crt_enabled)
+	const lo_dpr = $derived(pixel_dpr)
+	const is_dragging_look = $derived(input.is_dragging_look)
+	const drag_start_x = $derived(input.drag_start_x)
+	const drag_start_y = $derived(input.drag_start_y)
+	const is_pseudo_fullscreen = $derived(fullscreen.is_pseudo_fullscreen)
+	const is_fullscreen_active = $derived(fullscreen.is_active)
+	const is_started = $derived(session.is_session_started)
+	const is_touch = $derived(device.is_touch_primary)
+	const game_status = $derived(is_started ? label_game_started : '')
+	const is_alt = $derived(game_state.is_alt)
+	const is_crt_enabled = $derived(crt.is_crt_enabled)
 	// AA is intentionally derived from is_touch only — not is_crt_enabled. Toggling RETRO must
 	// not change the WebGL antialias setting, because that requires remounting <Canvas>, which
 	// resets the player position. When RETRO is on the CRT post-process (dither + barrel)
 	// overwrites the framebuffer with low-res pixels, so always-on AA is visually transparent.
-	let is_aa_enabled = $derived(should_use_antialias(is_touch))
+	const is_aa_enabled = $derived(should_use_antialias(is_touch))
 
 	function start_game(): void {
 		if (session.is_session_started) return
@@ -132,8 +132,11 @@
 		loading.set_step('loading_assets')
 		fullscreen_switch_input.set_container(container)
 		const canvas_el = container.querySelector<HTMLCanvasElement>('canvas')
-		if (!canvas_el)
+
+		if (!canvas_el) {
 			console.warn('[GameScene] No <canvas> found at mount — synthetic pointer events disabled')
+		}
+
 		const cleanup_input = input.setup_listeners(canvas_el)
 		const cleanup_fullscreen = fullscreen.setup_listeners()
 

--- a/src/lib/game-kit/GameScene.svelte.test.ts
+++ b/src/lib/game-kit/GameScene.svelte.test.ts
@@ -353,7 +353,7 @@ describe('GameScene', () => {
 		})
 
 		it('passes lo_dpr={pixel_dpr} to CrtDitherPass for the low-res game render stage', () => {
-			expect(GAME_SCENE_SOURCE).toContain('let lo_dpr = $derived(pixel_dpr)')
+			expect(GAME_SCENE_SOURCE).toMatch(/(?:let|const)\s+lo_dpr\s*=\s*\$derived\(pixel_dpr\)/u)
 			expect(GAME_SCENE_SOURCE).toContain('<CrtDitherPass {lo_dpr}')
 		})
 
@@ -407,10 +407,10 @@ describe('GameScene', () => {
 
 		it('GameScene no longer owns DOTS_PER_SCANLINE / device_pixel_ratio / scanline-derived state', () => {
 			expect(GAME_SCENE_SOURCE).not.toMatch(/const\s+DOTS_PER_SCANLINE\s*=/u)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/let\s+device_pixel_ratio\s*=\s*\$state\(/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/(?:let|const)\s+device_pixel_ratio\s*=\s*\$state\(/u)
 			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_period_css/u)
 			expect(GAME_SCENE_SOURCE).not.toMatch(/scanline_angle_css/u)
-			expect(GAME_SCENE_SOURCE).not.toMatch(/let\s+is_portrait\s*=\s*\$derived/u)
+			expect(GAME_SCENE_SOURCE).not.toMatch(/(?:let|const)\s+is_portrait\s*=\s*\$derived/u)
 		})
 
 		it('does not overlay a phosphor mask (RGB sub-pixel stripes) — kept off intentionally', () => {
@@ -436,13 +436,13 @@ describe('GameScene', () => {
 
 			// Negative: previous filter values must not be present on the canvas filter chain.
 			for (const prior of [
-				'contrast\\(1\\.08\\)',
-				'saturate\\(1\\.1\\)',
-				'brightness\\(1\\.15\\)',
+				String.raw`contrast\(1\.08\)`,
+				String.raw`saturate\(1\.1\)`,
+				String.raw`brightness\(1\.15\)`,
 			]) {
 				expect(GAME_SCENE_SOURCE).not.toMatch(
 					new RegExp(
-						`\\.game-container\\.crt-active\\s+:global\\(canvas\\)\\s*\\{[\\s\\S]*?filter:[^;]*${prior}`,
+						String.raw`\.game-container\.crt-active\s+:global\(canvas\)\s*\{[\s\S]*?filter:[^;]*${prior}`,
 						'u',
 					),
 				)
@@ -482,10 +482,15 @@ describe('GameScene', () => {
 			// flooded the periphery. We dropped corners to 0.4 so the screen edges stay
 			// readable while the curvature illusion still reads. Value-pin to catch
 			// regressions in either direction (back to 0.55 = too dark; to 0.25 = no curvature).
-			for (const corner of ['top\\s+left', 'top\\s+right', 'bottom\\s+left', 'bottom\\s+right']) {
+			for (const corner of [
+				String.raw`top\s+left`,
+				String.raw`top\s+right`,
+				String.raw`bottom\s+left`,
+				String.raw`bottom\s+right`,
+			]) {
 				expect(GAME_SCENE_SOURCE).toMatch(
 					new RegExp(
-						`radial-gradient\\(\\s*circle\\s+at\\s+${corner},\\s*rgba\\(\\s*0,\\s*0,\\s*0,\\s*0\\.4\\s*\\)`,
+						String.raw`radial-gradient\(\s*circle\s+at\s+${corner},\s*rgba\(\s*0,\s*0,\s*0,\s*0\.4\s*\)`,
 						'u',
 					),
 				)
@@ -572,7 +577,7 @@ describe('GameScene', () => {
 	describe('safe-area drawing when fullscreen is engaged (Issue #80)', () => {
 		it('derives is_fullscreen_active from fullscreen.is_active', () => {
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/let\s+is_fullscreen_active\s*=\s*\$derived\(\s*fullscreen\.is_active\s*\)/u,
+				/(?:let|const)\s+is_fullscreen_active\s*=\s*\$derived\(\s*fullscreen\.is_active\s*\)/u,
 			)
 		})
 
@@ -644,7 +649,7 @@ describe('GameScene', () => {
 			// Always-on AA on desktop is masked by the CRT post-process when RETRO is on, so we
 			// only need is_touch as the input.
 			expect(GAME_SCENE_SOURCE).toMatch(
-				/let\s+is_aa_enabled\s*=\s*\$derived\(\s*should_use_antialias\(\s*is_touch\s*\)\s*\)/u,
+				/(?:let|const)\s+is_aa_enabled\s*=\s*\$derived\(\s*should_use_antialias\(\s*is_touch\s*\)\s*\)/u,
 			)
 		})
 

--- a/src/lib/game-kit/audio.test.ts
+++ b/src/lib/game-kit/audio.test.ts
@@ -61,6 +61,7 @@ describe('game audio', () => {
 			'AudioContext',
 			class {
 				readonly state: AudioContextState = 'running'
+
 				constructor() {
 					instance_count += 1
 				}

--- a/src/lib/game-kit/controls/ControlsScene.svelte
+++ b/src/lib/game-kit/controls/ControlsScene.svelte
@@ -74,20 +74,20 @@
 		is_touch: boolean
 	}
 
-	let { hint_text, is_touch }: Props = $props()
+	const { hint_text, is_touch }: Props = $props()
 
 	const { size } = useThrelte()
 
 	// Font is driven by CRT state — CRT ON pairs the retro pixel font with the scanline
 	// aesthetic; CRT OFF switches to the modern Orbitron font.
-	let should_use_alt_font = $derived(!crt.is_crt_enabled)
-	let current_font = $derived(fonts.get_font(should_use_alt_font))
-	let current_font_size_mul = $derived(fonts.get_font_size_multiplier(should_use_alt_font))
-	let viewport_aspect = $derived($size.width / $size.height)
-	let view_width_at_plane = $derived(TOUCH_VIEW_HEIGHT_AT_PLANE * viewport_aspect)
-	let touch_world_width = $derived(view_width_at_plane * TOUCH_WIDTH_RATIO)
-	let touch_world_height = $derived(touch_world_width / TOUCH_SVG_ASPECT)
-	let pc_scale = $derived(
+	const should_use_alt_font = $derived(!crt.is_crt_enabled)
+	const current_font = $derived(fonts.get_font(should_use_alt_font))
+	const current_font_size_mul = $derived(fonts.get_font_size_multiplier(should_use_alt_font))
+	const viewport_aspect = $derived($size.width / $size.height)
+	const view_width_at_plane = $derived(TOUCH_VIEW_HEIGHT_AT_PLANE * viewport_aspect)
+	const touch_world_width = $derived(view_width_at_plane * TOUCH_WIDTH_RATIO)
+	const touch_world_height = $derived(touch_world_width / TOUCH_SVG_ASPECT)
+	const pc_scale = $derived(
 		compute_fit_scale(view_width_at_plane, PC_NATURAL_SPAN, PC_MIN_SIDE_PADDING),
 	)
 

--- a/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
+++ b/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
@@ -8,20 +8,20 @@ const DEFAULT_RENDER_ORDER_VALUE = 0
 
 function find_mesh_open_tag(source: string, position_marker: string): string {
 	const start_index = source.indexOf(position_marker)
-	if (start_index < 0) throw new Error(`mesh with marker "${position_marker}" not found`)
+	if (start_index === -1) throw new Error(`mesh with marker "${position_marker}" not found`)
 	const block_start = source.lastIndexOf('<T.Mesh', start_index)
 	const block_end = source.indexOf('>', start_index)
-	if (block_start < 0 || block_end < 0) throw new Error(`mesh open tag not bounded`)
+	if (block_start === -1 || block_end === -1) throw new Error(`mesh open tag not bounded`)
 
 	return source.slice(block_start, block_end + 1)
 }
 
 function find_mesh_full_block(source: string, position_marker: string): string {
 	const start_index = source.indexOf(position_marker)
-	if (start_index < 0) throw new Error(`mesh with marker "${position_marker}" not found`)
+	if (start_index === -1) throw new Error(`mesh with marker "${position_marker}" not found`)
 	const block_start = source.lastIndexOf('<T.Mesh', start_index)
 	const block_end = source.indexOf('</T.Mesh>', start_index)
-	if (block_start < 0 || block_end < 0) throw new Error(`mesh full block not bounded`)
+	if (block_start === -1 || block_end === -1) throw new Error(`mesh full block not bounded`)
 
 	return source.slice(block_start, block_end)
 }
@@ -35,10 +35,10 @@ function find_mesh_blocks_by_render_order(
 
 	while (cursor < source.length) {
 		const order_index = source.indexOf(render_order_token, cursor)
-		if (order_index < 0) break
+		if (order_index === -1) break
 		const block_start = source.lastIndexOf('<T.Mesh', order_index)
 		const block_end = source.indexOf('</T.Mesh>', order_index)
-		if (block_start < 0 || block_end < 0) break
+		if (block_start === -1 || block_end === -1) break
 		blocks.push(source.slice(block_start, block_end))
 		cursor = block_end + 1
 	}
@@ -283,7 +283,7 @@ describe('ControlsScene keyboard letters — overlaid as Threlte Text using the 
 
 	it('derives should_use_alt_font from !crt.is_crt_enabled — font swaps with CRT, not CYBER', () => {
 		expect(SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
+			/(?:let|const)\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 		expect(SOURCE).toMatch(
 			/import\s*\{[^}]*\bcrt\b[^}]*\}\s*from\s*'\$lib\/game-kit\/crt\.svelte'/u,
@@ -340,7 +340,7 @@ describe('ControlsScene texture loading — leak-safe blob URLs and unhandled re
 })
 
 function extract_const_number(source: string, name: string): number {
-	const re = new RegExp(`const\\s+${name}\\s*=\\s*(-?\\d+(?:\\.\\d+)?)`, 'u')
+	const re = new RegExp(String.raw`const\s+${name}\s*=\s*(-?\d+(?:\.\d+)?)`, 'u')
 	const match = source.match(re)
 	if (!match) throw new Error(`constant ${name} not found in source`)
 

--- a/src/lib/game-kit/controls/JumpIcon.svelte.test.ts
+++ b/src/lib/game-kit/controls/JumpIcon.svelte.test.ts
@@ -26,7 +26,7 @@ describe('JumpIcon', () => {
 
 	it('uses original Jump C coordinates (bottom solid, top animated)', () => {
 		const { container } = render(JumpIcon)
-		const polylines = Array.from(container.querySelectorAll('polyline'))
+		const polylines = [...container.querySelectorAll('polyline')]
 
 		expect(polylines[0]?.getAttribute('points')).toBe('8,27 20,15 32,27')
 		expect(polylines[1]?.getAttribute('points')).toBe('8,19 20,7 32,19')

--- a/src/lib/game-kit/controls/KeyboardDiagram.svelte
+++ b/src/lib/game-kit/controls/KeyboardDiagram.svelte
@@ -5,7 +5,7 @@
 		label_return: string
 	}
 
-	let { label_move, label_jump, label_return }: Props = $props()
+	const { label_move, label_jump, label_return }: Props = $props()
 
 	type LetterKey = {
 		class_name: string

--- a/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
@@ -22,7 +22,7 @@ describe('KeyboardDiagram', () => {
 
 	it('does not render a visible move label text', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
-		const texts = Array.from(container.querySelectorAll('text'))
+		const texts = [...container.querySelectorAll('text')]
 		const move_label = texts.find((t) => t.textContent?.trim() === PROPS.label_move)
 
 		expect(move_label).toBeUndefined()
@@ -30,7 +30,7 @@ describe('KeyboardDiagram', () => {
 
 	it('renders ESC text centered in its key (dominant-baseline central)', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
-		const texts = Array.from(container.querySelectorAll('text'))
+		const texts = [...container.querySelectorAll('text')]
 		const esc = texts.find((t) => t.textContent?.trim() === 'ESC')
 
 		expect(esc).toBeTruthy()
@@ -47,7 +47,7 @@ describe('KeyboardDiagram', () => {
 
 	it('uses Orbitron font for key labels', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
-		const texts = Array.from(container.querySelectorAll('text'))
+		const texts = [...container.querySelectorAll('text')]
 		const has_orbitron = texts.every((t) => t.getAttribute('font-family')?.includes('Orbitron'))
 
 		expect(has_orbitron).toBe(true)
@@ -55,7 +55,7 @@ describe('KeyboardDiagram', () => {
 
 	it('spacebar uses double chevron (two 3-point polylines, no straight line)', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
-		const polylines = Array.from(container.querySelectorAll('.key-space polyline'))
+		const polylines = [...container.querySelectorAll('.key-space polyline')]
 
 		expect(polylines).toHaveLength(2)
 
@@ -68,7 +68,7 @@ describe('KeyboardDiagram', () => {
 
 	it('spacebar chevron is text-sized (total span <= 13 units, similar to WASD font-size)', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
-		const polylines = Array.from(container.querySelectorAll('.key-space polyline'))
+		const polylines = [...container.querySelectorAll('.key-space polyline')]
 		const all_y_values = polylines.flatMap(
 			(p) =>
 				p

--- a/src/lib/game-kit/controls/MouseDiagram.svelte
+++ b/src/lib/game-kit/controls/MouseDiagram.svelte
@@ -4,7 +4,7 @@
 		label_look: string
 	}
 
-	let { label_action, label_look }: Props = $props()
+	const { label_action, label_look }: Props = $props()
 </script>
 
 <svg

--- a/src/lib/game-kit/controls/MouseDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/MouseDiagram.svelte.test.ts
@@ -13,7 +13,7 @@ describe('MouseDiagram', () => {
 
 	it('does not render visible action label text', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
-		const texts = Array.from(container.querySelectorAll('text'))
+		const texts = [...container.querySelectorAll('text')]
 		const action = texts.find((t) => t.textContent?.trim() === PROPS.label_action)
 
 		expect(action).toBeUndefined()
@@ -21,7 +21,7 @@ describe('MouseDiagram', () => {
 
 	it('does not render visible look label text', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
-		const texts = Array.from(container.querySelectorAll('text'))
+		const texts = [...container.querySelectorAll('text')]
 		const look = texts.find((t) => t.textContent?.trim() === PROPS.label_look)
 
 		expect(look).toBeUndefined()
@@ -29,7 +29,7 @@ describe('MouseDiagram', () => {
 
 	it('does not render scroll wheel', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
-		const rects = Array.from(container.querySelectorAll('rect'))
+		const rects = [...container.querySelectorAll('rect')]
 		const wheel = rects.find(
 			(r) => r.getAttribute('rx') === '5' && r.getAttribute('width') === '10',
 		)
@@ -51,7 +51,7 @@ describe('MouseDiagram', () => {
 
 	it('all stroke-widths are <= 1 to match keyboard visual stroke width', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
-		const stroked = Array.from(container.querySelectorAll('[stroke-width]'))
+		const stroked = [...container.querySelectorAll('[stroke-width]')]
 
 		expect(stroked.length).toBeGreaterThan(0)
 

--- a/src/lib/game-kit/controls/TouchDiagram.svelte
+++ b/src/lib/game-kit/controls/TouchDiagram.svelte
@@ -5,7 +5,7 @@
 		label_action: string
 	}
 
-	let { label_move, label_look, label_action }: Props = $props()
+	const { label_move, label_look, label_action }: Props = $props()
 </script>
 
 {#snippet swipe_gesture(animation_class: string)}

--- a/src/lib/game-kit/controls/TouchDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/TouchDiagram.svelte.test.ts
@@ -41,7 +41,7 @@ describe('TouchDiagram', () => {
 
 	it('does not render any visible label text', () => {
 		const { container } = render(TouchDiagram, { props: PROPS })
-		const texts = Array.from(container.querySelectorAll('text'))
+		const texts = [...container.querySelectorAll('text')]
 
 		expect(texts).toHaveLength(0)
 	})

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte
@@ -9,7 +9,7 @@
 		show_jump?: boolean
 	}
 
-	let { label_jump, show_jump = true }: Props = $props()
+	const { label_jump, show_jump = true }: Props = $props()
 
 	let move_zone: HTMLElement
 	let look_zone: HTMLElement
@@ -192,7 +192,7 @@
 	}
 
 	onMount(() => {
-		if (!('ontouchstart' in window)) return
+		if (!('ontouchstart' in globalThis)) return
 		move_zone.addEventListener('touchstart', on_move_start, { passive: false })
 		look_zone.addEventListener('touchstart', on_look_start, { passive: false })
 		document.addEventListener('touchmove', on_touch_move, { passive: false })

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte.test.ts
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte.test.ts
@@ -28,8 +28,8 @@ function setup_threlte_dom(): { dom: HTMLDivElement; canvas: HTMLCanvasElement }
 	const dom = document.createElement('div')
 	const canvas = document.createElement('canvas')
 
-	dom.appendChild(canvas)
-	document.body.appendChild(dom)
+	dom.append(canvas)
+	document.body.append(dom)
 
 	return { dom, canvas }
 }

--- a/src/lib/game-kit/crt-barrel.test.ts
+++ b/src/lib/game-kit/crt-barrel.test.ts
@@ -16,7 +16,7 @@ function distance_from_center(x: number, y: number): number {
 	const dx = x - CENTER_X
 	const dy = y - CENTER_Y
 
-	return Math.sqrt(dx * dx + dy * dy)
+	return Math.hypot(dx, dy)
 }
 
 describe('crt-barrel constants', () => {
@@ -69,10 +69,10 @@ describe('crt_barrel.apply_barrel_uv', () => {
 
 	it('pushes off-center UVs OUTWARD (distance from center grows) when strength > 0', () => {
 		const off_center_samples: ReadonlyArray<BarrelUv> = [
-			{ x: 0.0, y: 0.5 },
-			{ x: 1.0, y: 0.5 },
-			{ x: 0.5, y: 0.0 },
-			{ x: 0.5, y: 1.0 },
+			{ x: 0, y: 0.5 },
+			{ x: 1, y: 0.5 },
+			{ x: 0.5, y: 0 },
+			{ x: 0.5, y: 1 },
 			{ x: 0.2, y: 0.2 },
 			{ x: 0.8, y: 0.8 },
 		]

--- a/src/lib/game-kit/crt-dither.test.ts
+++ b/src/lib/game-kit/crt-dither.test.ts
@@ -193,7 +193,7 @@ describe('BAYER_MATRIX', () => {
 
 describe('crt_dither.quantize_with_dither_2d', () => {
 	const MID_GREY = 0.5
-	const VERY_DARK = 0.0
+	const VERY_DARK = 0
 	const BAYER_LOW = 0 / SQUARED_BAYER_SIZE
 	const BAYER_HIGH = MAX_BAYER_VALUE / SQUARED_BAYER_SIZE
 
@@ -287,13 +287,14 @@ describe('crt_dither.create_bayer_texture', () => {
 		const tex = crt_dither.create_bayer_texture()
 		const data = tex.image.data as Float32Array
 
-		BAYER_MATRIX.forEach((row, y) => {
-			row.forEach((source, x) => {
+		for (const [y, row] of BAYER_MATRIX.entries()) {
+			for (const [x, source] of row.entries()) {
 				const expected = source / SQUARED_BAYER_SIZE
 
 				expect(data[y * BAYER_SIZE + x]).toBeCloseTo(expected, 6)
-			})
-		})
+			}
+		}
+
 		tex.dispose()
 	})
 })

--- a/src/lib/game-kit/crt-dither.ts
+++ b/src/lib/game-kit/crt-dither.ts
@@ -68,11 +68,12 @@ function create_bayer_texture(): DataTexture {
 	const cells = BAYER_SIZE_VALUE * BAYER_SIZE_VALUE
 	const data = new Float32Array(cells)
 
-	BAYER_MATRIX.forEach((row, y) => {
-		row.forEach((value, x) => {
+	for (const [y, row] of BAYER_MATRIX.entries()) {
+		for (const [x, value] of row.entries()) {
 			data[y * BAYER_SIZE_VALUE + x] = value / cells
-		})
-	})
+		}
+	}
+
 	const texture = new DataTexture(data, BAYER_SIZE_VALUE, BAYER_SIZE_VALUE, RedFormat, FloatType)
 
 	texture.minFilter = NearestFilter
@@ -95,13 +96,13 @@ function compute_scanline_factor(
 	coord: number,
 	period: number,
 	dark_factor: number,
-	sharpness: number = 1,
+	sharpness = 1,
 ): number {
 	const HALF = 0.5
 	const TWO_PI = 2 * Math.PI
 	const phase = ((coord % period) + period) % period
 	const wave_cos = HALF * (1 - Math.cos((TWO_PI * phase) / period))
-	const wave = Math.pow(wave_cos, sharpness)
+	const wave = wave_cos ** sharpness
 
 	return dark_factor + wave * (1 - dark_factor)
 }

--- a/src/lib/game-kit/display/ScoreDisplay.svelte
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte
@@ -42,7 +42,7 @@
 		label_current: string
 	}
 
-	let { score_data, is_alt, position_z, label_high_score, label_round, label_current }: Props =
+	const { score_data, is_alt, position_z, label_high_score, label_round, label_current }: Props =
 		$props()
 
 	let displayed_score = $state(0)
@@ -90,24 +90,24 @@
 	useTask(tick)
 
 	// Font is driven by CRT state via fonts.get_active_*; is_alt only drives the palette.
-	let current_font = $derived(fonts.get_active_font())
-	let font_size_multiplier = $derived(fonts.get_active_font_size_multiplier())
-	let panel_color = $derived(is_alt ? CYBER_PANEL_COLOR : RETRO_PANEL_COLOR)
-	let panel_emissive = $derived(is_alt ? CYBER_PANEL_EMISSIVE : RETRO_PANEL_EMISSIVE)
-	let panel_emissive_intensity = $derived(
+	const current_font = $derived(fonts.get_active_font())
+	const font_size_multiplier = $derived(fonts.get_active_font_size_multiplier())
+	const panel_color = $derived(is_alt ? CYBER_PANEL_COLOR : RETRO_PANEL_COLOR)
+	const panel_emissive = $derived(is_alt ? CYBER_PANEL_EMISSIVE : RETRO_PANEL_EMISSIVE)
+	const panel_emissive_intensity = $derived(
 		is_alt ? CYBER_PANEL_EMISSIVE_INTENSITY : RETRO_PANEL_EMISSIVE_INTENSITY,
 	)
-	let label_color = $derived(is_alt ? CYBER_LABEL_COLOR : RETRO_LABEL_COLOR)
-	let value_color = $derived(is_alt ? CYBER_VALUE_COLOR : RETRO_VALUE_COLOR)
-	let label_font_size = $derived(LABEL_FONT_SIZE * font_size_multiplier)
-	let value_font_size = $derived(VALUE_FONT_SIZE * font_size_multiplier)
-	let round_font_size = $derived(ROUND_VALUE_FONT_SIZE * font_size_multiplier)
+	const label_color = $derived(is_alt ? CYBER_LABEL_COLOR : RETRO_LABEL_COLOR)
+	const value_color = $derived(is_alt ? CYBER_VALUE_COLOR : RETRO_VALUE_COLOR)
+	const label_font_size = $derived(LABEL_FONT_SIZE * font_size_multiplier)
+	const value_font_size = $derived(VALUE_FONT_SIZE * font_size_multiplier)
+	const round_font_size = $derived(ROUND_VALUE_FONT_SIZE * font_size_multiplier)
 
-	let hi_value_color = $derived(get_hi_value_color(is_alt, score_data.is_new_high_score))
-	let hi_score_text = $derived(score_data.format_score(displayed_hi))
-	let current_score_text = $derived(score_data.format_score(displayed_score))
-	let hi_round_text = $derived(String(score_data.high_score_round))
-	let round_text = $derived(String(score_data.last_cleared_round))
+	const hi_value_color = $derived(get_hi_value_color(is_alt, score_data.is_new_high_score))
+	const hi_score_text = $derived(score_data.format_score(displayed_hi))
+	const current_score_text = $derived(score_data.format_score(displayed_score))
+	const hi_round_text = $derived(String(score_data.high_score_round))
+	const round_text = $derived(String(score_data.last_cleared_round))
 </script>
 
 <T.Group position={[0, DISPLAY_Y, position_z]} rotation.x={PANEL_TILT_X}>

--- a/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
@@ -84,13 +84,13 @@ describe('ScoreDisplay', () => {
 describe('ScoreDisplay font selection — driven by CRT-aware fonts helpers, not by is_alt (CYBER)', () => {
 	it('current_font uses fonts.get_active_font() (no caller-supplied flag)', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_active_font\(\s*\)\s*\)/u,
+			/(?:let|const)\s+current_font\s*=\s*\$derived\(\s*fonts\.get_active_font\(\s*\)\s*\)/u,
 		)
 	})
 
 	it('font_size_multiplier uses fonts.get_active_font_size_multiplier()', () => {
 		expect(SCORE_DISPLAY_SOURCE).toMatch(
-			/let\s+font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_active_font_size_multiplier\(\s*\)\s*\)/u,
+			/(?:let|const)\s+font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_active_font_size_multiplier\(\s*\)\s*\)/u,
 		)
 	})
 
@@ -106,7 +106,9 @@ describe('ScoreDisplay font selection — driven by CRT-aware fonts helpers, not
 	})
 
 	it('keeps is_alt prop driving palette decisions (panel/label/value colors)', () => {
-		expect(SCORE_DISPLAY_SOURCE).toMatch(/let\s+panel_color\s*=\s*\$derived\(\s*is_alt\s*\?/u)
+		expect(SCORE_DISPLAY_SOURCE).toMatch(
+			/(?:let|const)\s+panel_color\s*=\s*\$derived\(\s*is_alt\s*\?/u,
+		)
 	})
 
 	it('does not pass is_alt into any fonts helper (font axis is CRT, not CYBER)', () => {

--- a/src/lib/game-kit/fullscreen.svelte.test.ts
+++ b/src/lib/game-kit/fullscreen.svelte.test.ts
@@ -8,7 +8,7 @@ describe('fullscreen', () => {
 	beforeEach(() => {
 		cleanup = fullscreen.setup_listeners()
 		el = document.createElement('div')
-		document.body.appendChild(el)
+		document.body.append(el)
 	})
 
 	afterEach(() => {

--- a/src/lib/game-kit/input/input.svelte.test.ts
+++ b/src/lib/game-kit/input/input.svelte.test.ts
@@ -34,19 +34,18 @@ function end_right_drag(): void {
 function make_zero_rect_target(): HTMLElement {
 	const target = document.createElement('div')
 
-	document.body.appendChild(target)
-	target.getBoundingClientRect = (): DOMRect =>
-		({
-			left: 0,
-			top: 0,
-			right: 800,
-			bottom: 600,
-			width: 800,
-			height: 600,
-			x: 0,
-			y: 0,
-			toJSON: () => ({}),
-		}) as DOMRect
+	document.body.append(target)
+	target.getBoundingClientRect = (): DOMRect => ({
+		left: 0,
+		top: 0,
+		right: 800,
+		bottom: 600,
+		width: 800,
+		height: 600,
+		x: 0,
+		y: 0,
+		toJSON: () => ({}),
+	})
 
 	return target
 }
@@ -71,7 +70,7 @@ describe('input', () => {
 
 	beforeEach(() => {
 		canvas_el = document.createElement('canvas')
-		document.body.appendChild(canvas_el)
+		document.body.append(canvas_el)
 		cleanup = input.setup_listeners(canvas_el)
 	})
 
@@ -224,7 +223,7 @@ describe('input', () => {
 	it('right mouse down requests pointer lock on event target', () => {
 		const target = document.createElement('div')
 
-		document.body.appendChild(target)
+		document.body.append(target)
 		const spy = vi.spyOn(target, 'requestPointerLock').mockResolvedValue()
 
 		dispatch_mouse_with_target('mousedown', { button: RIGHT_BUTTON }, target)

--- a/src/lib/game-kit/input/input.svelte.ts
+++ b/src/lib/game-kit/input/input.svelte.ts
@@ -112,10 +112,22 @@ function override_offset_during_drag_impl(s: InputState, event: Event): void {
 
 function on_left_mouse_for_synth_impl(s: InputState, e: MouseEvent, refs: InputRefs): void {
 	if (!s.is_dragging_look || e.button !== 0) return
-	if (e.type === 'mousedown')
-		dispatch_synthetic_pointer('pointerdown', s.drag_start_x, s.drag_start_y, refs.canvas_el)
-	else if (e.type === 'mouseup')
-		dispatch_synthetic_pointer('pointerup', s.drag_start_x, s.drag_start_y, refs.canvas_el)
+
+	switch (e.type) {
+		case 'mousedown': {
+			dispatch_synthetic_pointer('pointerdown', s.drag_start_x, s.drag_start_y, refs.canvas_el)
+			break
+		}
+
+		case 'mouseup': {
+			{
+				dispatch_synthetic_pointer('pointerup', s.drag_start_x, s.drag_start_y, refs.canvas_el)
+				// No default
+			}
+
+			break
+		}
+	}
 }
 
 function on_key_impl(s: InputState, e: KeyboardEvent, is_down: boolean): void {

--- a/src/lib/game-kit/input/joystick-dispatch.test.ts
+++ b/src/lib/game-kit/input/joystick-dispatch.test.ts
@@ -12,6 +12,7 @@ const RECT_TOP = 200
 
 class FakeEvent {
 	type: string
+
 	constructor(type: string) {
 		this.type = type
 	}

--- a/src/lib/game-kit/input/joystick-dispatch.ts
+++ b/src/lib/game-kit/input/joystick-dispatch.ts
@@ -53,7 +53,7 @@ function dispatch_pointer_up(
 	is_primary: boolean,
 	x: number,
 	y: number,
-	is_tap: boolean = true,
+	is_tap = true,
 ): void {
 	const ctx = get_dispatch_ctx(x, y)
 	if (!ctx) return

--- a/src/lib/game-kit/input/pointer-compute.svelte.test.ts
+++ b/src/lib/game-kit/input/pointer-compute.svelte.test.ts
@@ -23,28 +23,22 @@ function make_camera() {
 	return { current: new PerspectiveCamera() }
 }
 
-function make_target(
-	client_w: number,
-	client_h: number,
-	rect_left: number = 0,
-	rect_top: number = 0,
-): HTMLElement {
+function make_target(client_w: number, client_h: number, rect_left = 0, rect_top = 0): HTMLElement {
 	const el = document.createElement('div')
 
 	Object.defineProperty(el, 'clientWidth', { get: () => client_w })
 	Object.defineProperty(el, 'clientHeight', { get: () => client_h })
-	el.getBoundingClientRect = (): DOMRect =>
-		({
-			left: rect_left,
-			top: rect_top,
-			right: rect_left + client_w,
-			bottom: rect_top + client_h,
-			width: client_w,
-			height: client_h,
-			x: rect_left,
-			y: rect_top,
-			toJSON: () => ({}),
-		}) as DOMRect
+	el.getBoundingClientRect = (): DOMRect => ({
+		left: rect_left,
+		top: rect_top,
+		right: rect_left + client_w,
+		bottom: rect_top + client_h,
+		width: client_w,
+		height: client_h,
+		x: rect_left,
+		y: rect_top,
+		toJSON: () => ({}),
+	})
 
 	return el
 }

--- a/src/lib/game-kit/listener-manager.ts
+++ b/src/lib/game-kit/listener-manager.ts
@@ -17,8 +17,10 @@ export function create_listener_manager(specs: ReadonlyArray<ListenerSpec>) {
 			for (const spec of specs) spec.target.addEventListener(spec.type, spec.handler, spec.options)
 
 			cleanup_fn = function cleanup(): void {
-				for (const spec of specs)
+				for (const spec of specs) {
 					spec.target.removeEventListener(spec.type, spec.handler, spec.options)
+				}
+
 				cleanup_fn = null
 				on_cleanup?.()
 			}

--- a/src/lib/game-kit/loading.svelte.ts
+++ b/src/lib/game-kit/loading.svelte.ts
@@ -8,7 +8,7 @@ const INITIAL_PROGRESS = '0%'
 const READY_PROGRESS_VALUE = 100
 
 interface LoadingObserver {
-	disconnect(): void
+	disconnect: () => void
 }
 
 type LoadingState<T extends string> = {

--- a/src/lib/game-kit/player/Player.svelte
+++ b/src/lib/game-kit/player/Player.svelte
@@ -14,14 +14,14 @@
 	const NEAR_PLANE = 0.1
 	const FAR_PLANE = 50
 	const JOYSTICK_LOOK_SPEED = 2
-	const GAMEOVER_SHAKE_STRENGTH = 1.0
+	const GAMEOVER_SHAKE_STRENGTH = 1
 	const KEYBOARD_AXIS_FRACTION = 0.5
 
 	interface Props {
 		is_gameover: boolean
 	}
 
-	let { is_gameover }: Props = $props()
+	const { is_gameover }: Props = $props()
 
 	let pos_x = $state(SPAWN_X)
 	let pos_y = $state(SPAWN_Y)

--- a/src/lib/game-kit/scene/FloorCredits.svelte
+++ b/src/lib/game-kit/scene/FloorCredits.svelte
@@ -24,12 +24,12 @@
 		scroll_end_z: number
 	}
 
-	let { is_alt, credits, scroll_start_z, scroll_end_z }: Props = $props()
+	const { is_alt, credits, scroll_start_z, scroll_end_z }: Props = $props()
 
 	// Font is driven by CRT state, independent of is_alt (CYBER) palette.
-	let should_use_alt_font = $derived(!crt.is_crt_enabled)
-	let current_font = $derived(fonts.get_font(should_use_alt_font))
-	let color = $derived(is_alt ? CREDITS_CYBER_COLOR : CREDITS_NORMAL_COLOR)
+	const should_use_alt_font = $derived(!crt.is_crt_enabled)
+	const current_font = $derived(fonts.get_font(should_use_alt_font))
+	const color = $derived(is_alt ? CREDITS_CYBER_COLOR : CREDITS_NORMAL_COLOR)
 	let scroll_z = $state(untrack(() => scroll_start_z))
 
 	function tick(delta: number): void {

--- a/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
+++ b/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
@@ -49,13 +49,13 @@ describe('FloorCredits', () => {
 describe('FloorCredits font selection — driven by CRT, not CYBER (is_alt)', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled', () => {
 		expect(FLOOR_CREDITS_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
+			/(?:let|const)\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('current_font passes should_use_alt_font into fonts.get_font (not is_alt)', () => {
 		expect(FLOOR_CREDITS_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
+			/(?:let|const)\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 	})
 
@@ -66,7 +66,7 @@ describe('FloorCredits font selection — driven by CRT, not CYBER (is_alt)', ()
 	})
 
 	it('keeps is_alt prop driving the credits color (CYBER vs normal)', () => {
-		expect(FLOOR_CREDITS_SOURCE).toMatch(/let\s+color\s*=\s*\$derived\(\s*is_alt\s*\?/u)
+		expect(FLOOR_CREDITS_SOURCE).toMatch(/(?:let|const)\s+color\s*=\s*\$derived\(\s*is_alt\s*\?/u)
 	})
 
 	it('does not pass is_alt directly into fonts helpers', () => {

--- a/src/lib/game-kit/scene/Room.svelte
+++ b/src/lib/game-kit/scene/Room.svelte
@@ -15,7 +15,7 @@
 		ceiling_color: string
 	}
 
-	let {
+	const {
 		width = DEFAULT_W,
 		depth = DEFAULT_D,
 		height = DEFAULT_H,
@@ -23,9 +23,9 @@
 		wall_color,
 		ceiling_color,
 	}: Props = $props()
-	let half_w = $derived(width / HALF_DIVISOR)
-	let half_d = $derived(depth / HALF_DIVISOR)
-	let half_h = $derived(height / HALF_DIVISOR)
+	const half_w = $derived(width / HALF_DIVISOR)
+	const half_d = $derived(depth / HALF_DIVISOR)
+	const half_h = $derived(height / HALF_DIVISOR)
 </script>
 
 <!-- Floor -->

--- a/src/lib/game-kit/scene/SceneObjects.svelte
+++ b/src/lib/game-kit/scene/SceneObjects.svelte
@@ -68,7 +68,7 @@
 		score_display_z: number
 	}
 
-	let {
+	const {
 		game_board,
 		score_data,
 		is_gameover,
@@ -82,22 +82,22 @@
 	const { camera } = useThrelte()
 	interactivity({ compute: make_pointer_compute(camera) })
 
-	let is_alt = $derived(game_state.is_alt)
+	const is_alt = $derived(game_state.is_alt)
 	// Font is driven by CRT state — CRT ON pairs the retro pixel font with the scanline
 	// aesthetic; CRT OFF switches to the modern Orbitron font. CYBER (is_alt) controls
 	// palette and lighting only.
-	let should_use_alt_font = $derived(!crt.is_crt_enabled)
-	let bg_color = $derived(is_alt ? CYBER_BG : NORMAL_BG)
-	let ambient_intensity = $derived(lighting.get_ambient_intensity(is_alt))
-	let ambient_color = $derived(lighting.get_ambient_color(is_alt))
-	let point_light_intensity = $derived(lighting.get_point_light_intensity(is_alt))
-	let point_light_color = $derived(is_alt ? CYBER_POINT_LIGHT_COLOR : NORMAL_POINT_LIGHT_COLOR)
-	let current_font = $derived(fonts.get_font(should_use_alt_font))
-	let current_font_size_multiplier = $derived(fonts.get_font_size_multiplier(should_use_alt_font))
-	let current_title_font_size = $derived(TITLE_FONT_SIZE * current_font_size_multiplier)
-	let floor_color = $derived(is_alt ? CYBER_FLOOR_COLOR : FLOOR_COLOR)
-	let wall_color = $derived(is_alt ? CYBER_WALL_COLOR : WALL_COLOR)
-	let ceiling_color = $derived(is_alt ? CYBER_CEILING_COLOR : CEILING_COLOR)
+	const should_use_alt_font = $derived(!crt.is_crt_enabled)
+	const bg_color = $derived(is_alt ? CYBER_BG : NORMAL_BG)
+	const ambient_intensity = $derived(lighting.get_ambient_intensity(is_alt))
+	const ambient_color = $derived(lighting.get_ambient_color(is_alt))
+	const point_light_intensity = $derived(lighting.get_point_light_intensity(is_alt))
+	const point_light_color = $derived(is_alt ? CYBER_POINT_LIGHT_COLOR : NORMAL_POINT_LIGHT_COLOR)
+	const current_font = $derived(fonts.get_font(should_use_alt_font))
+	const current_font_size_multiplier = $derived(fonts.get_font_size_multiplier(should_use_alt_font))
+	const current_title_font_size = $derived(TITLE_FONT_SIZE * current_font_size_multiplier)
+	const floor_color = $derived(is_alt ? CYBER_FLOOR_COLOR : FLOOR_COLOR)
+	const wall_color = $derived(is_alt ? CYBER_WALL_COLOR : WALL_COLOR)
+	const ceiling_color = $derived(is_alt ? CYBER_CEILING_COLOR : CEILING_COLOR)
 	let title_y = $state(TITLE_Y)
 
 	function tick(): void {

--- a/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
+++ b/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
@@ -128,19 +128,19 @@ describe('SceneObjects', () => {
 describe('SceneObjects font selection — driven by CRT, not CYBER (is_alt)', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled (font swaps with CRT, not CYBER)', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
+			/(?:let|const)\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('current_font passes should_use_alt_font into fonts.get_font (not is_alt)', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
+			/(?:let|const)\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 	})
 
 	it('current_font_size_multiplier passes should_use_alt_font into fonts.get_font_size_multiplier', () => {
 		expect(SCENE_OBJECTS_SOURCE).toMatch(
-			/let\s+current_font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)\s*\)/u,
+			/(?:let|const)\s+current_font_size_multiplier\s*=\s*\$derived\(\s*fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 	})
 

--- a/src/lib/game-kit/switch/Switch.svelte
+++ b/src/lib/game-kit/switch/Switch.svelte
@@ -72,7 +72,7 @@
 		panel_text?: string | undefined
 	}
 
-	let {
+	const {
 		position_x,
 		is_active,
 		icon_type,
@@ -82,31 +82,33 @@
 		onclick,
 		colors,
 		geometry = {},
-		panel_text = undefined,
+		panel_text,
 	}: Props = $props()
 
-	let geom: Required<SwitchGeometry> = $derived({ ...DEFAULT_SWITCH_GEOMETRY, ...geometry })
-	let border_pos = $derived(geom.panel_size / 2 - geom.border_thickness / 2)
-	let corner_geom: CornerGeom = $derived({
+	const geom: Required<SwitchGeometry> = $derived({ ...DEFAULT_SWITCH_GEOMETRY, ...geometry })
+	const border_pos = $derived(geom.panel_size / 2 - geom.border_thickness / 2)
+	const corner_geom: CornerGeom = $derived({
 		arm: geom.corner_arm,
 		thickness: geom.corner_thickness,
 		pos: geom.corner_pos,
 		arm_center: geom.corner_pos - geom.corner_arm / 2,
 	})
-	let corner_bars = $derived(
+	const corner_bars = $derived(
 		CORNER_SIGNS.flatMap(function (sx) {
 			return CORNER_SIGNS.flatMap(function (sy) {
 				return [make_bar(sx, sy, 'h', corner_geom), make_bar(sx, sy, 'v', corner_geom)]
 			})
 		}),
 	)
-	let hit_area_w = $derived(geom.panel_size + HIT_AREA_PADDING)
-	let hit_area_h = $derived(geom.panel_size + HIT_AREA_PADDING)
+	const hit_area_w = $derived(geom.panel_size + HIT_AREA_PADDING)
+	const hit_area_h = $derived(geom.panel_size + HIT_AREA_PADDING)
 
-	let resolved = $derived(resolve_switch_colors(colors, is_active))
-	let panel_opacity = $derived(is_active ? geom.panel_opacity_active : geom.panel_opacity_inactive)
-	let current_font_size = $derived(geom.label_font_size * font_size_multiplier)
-	let current_panel_text_font_size = $derived(geom.panel_text_font_size * font_size_multiplier)
+	const resolved = $derived(resolve_switch_colors(colors, is_active))
+	const panel_opacity = $derived(
+		is_active ? geom.panel_opacity_active : geom.panel_opacity_inactive,
+	)
+	const current_font_size = $derived(geom.label_font_size * font_size_multiplier)
+	const current_panel_text_font_size = $derived(geom.panel_text_font_size * font_size_multiplier)
 
 	// MeshStandardMaterial for panel_text so the digits emit light at the same color and
 	// intensity as the border frame ("枠"). Troika Text's default MeshBasicMaterial has

--- a/src/lib/game-kit/switch/fullscreen-switch-input.svelte.test.ts
+++ b/src/lib/game-kit/switch/fullscreen-switch-input.svelte.test.ts
@@ -12,7 +12,7 @@ describe('fullscreen_switch_input', () => {
 		session.reset_session()
 		cleanup_fullscreen = fullscreen.setup_listeners()
 		container = document.createElement('div')
-		document.body.appendChild(container)
+		document.body.append(container)
 		fullscreen_switch_input.set_container(container)
 		vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
 	})

--- a/src/lib/game/Board.svelte
+++ b/src/lib/game/Board.svelte
@@ -50,7 +50,7 @@
 
 	const BUTTON_CONFIGS = [
 		{
-			color: 'green' as ButtonColor,
+			color: 'green',
 			rotation: 0,
 			lit_color: '#00ff00',
 			dim_color: '#003300',
@@ -58,7 +58,7 @@
 			cyber_dim_color: '#005533',
 		},
 		{
-			color: 'red' as ButtonColor,
+			color: 'red',
 			rotation: Math.PI / 2,
 			lit_color: '#ff2222',
 			dim_color: '#330000',
@@ -66,7 +66,7 @@
 			cyber_dim_color: '#550022',
 		},
 		{
-			color: 'yellow' as ButtonColor,
+			color: 'yellow',
 			rotation: Math.PI,
 			lit_color: '#ffff00',
 			dim_color: '#333300',
@@ -74,7 +74,7 @@
 			cyber_dim_color: '#555500',
 		},
 		{
-			color: 'blue' as ButtonColor,
+			color: 'blue',
 			rotation: -Math.PI / 2,
 			lit_color: '#2266ff',
 			dim_color: '#001133',
@@ -83,7 +83,7 @@
 		},
 	] as const satisfies ReadonlyArray<ButtonConfig>
 
-	let { game_data, is_alt, text_gameover, text_start }: Props = $props()
+	const { game_data, is_alt, text_gameover, text_start }: Props = $props()
 
 	function is_lit(color: ButtonColor): boolean {
 		return (
@@ -115,19 +115,19 @@
 		return FONT_SIZE
 	}
 
-	let is_multiline_center = $derived(game_data.phase === 'gameover')
-	let center_text = $derived(get_center_text())
-	let emissive_intensity = $derived(
+	const is_multiline_center = $derived(game_data.phase === 'gameover')
+	const center_text = $derived(get_center_text())
+	const emissive_intensity = $derived(
 		(is_alt ? CYBER_EMISSIVE_INTENSITY : EMISSIVE_INTENSITY) * game_data.flash_intensity,
 	)
 	// Font is driven by CRT state, independent of is_alt (CYBER) palette.
-	let should_use_alt_font = $derived(!crt.is_crt_enabled)
-	let current_font = $derived(fonts.get_font(should_use_alt_font))
-	let center_base_font_size = $derived(get_center_base_font_size())
-	let current_font_size = $derived(
+	const should_use_alt_font = $derived(!crt.is_crt_enabled)
+	const current_font = $derived(fonts.get_font(should_use_alt_font))
+	const center_base_font_size = $derived(get_center_base_font_size())
+	const current_font_size = $derived(
 		center_base_font_size * fonts.get_font_size_multiplier(should_use_alt_font),
 	)
-	let current_line_height = $derived(
+	const current_line_height = $derived(
 		is_multiline_center ? MULTILINE_LINE_HEIGHT : SINGLE_LINE_HEIGHT,
 	)
 </script>

--- a/src/lib/game/Board.svelte.test.ts
+++ b/src/lib/game/Board.svelte.test.ts
@@ -74,13 +74,13 @@ describe('Board', () => {
 describe('Board font selection — driven by CRT, not CYBER (is_alt)', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
+			/(?:let|const)\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 
 	it('current_font and current_font_size use should_use_alt_font (not is_alt)', () => {
 		expect(BOARD_SOURCE).toMatch(
-			/let\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
+			/(?:let|const)\s+current_font\s*=\s*\$derived\(\s*fonts\.get_font\(\s*should_use_alt_font\s*\)\s*\)/u,
 		)
 		expect(BOARD_SOURCE).toMatch(/fonts\.get_font_size_multiplier\(\s*should_use_alt_font\s*\)/u)
 	})
@@ -166,7 +166,7 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 		expect(BOARD_SOURCE).toMatch(/<Text[\s\S]*lineHeight=\{current_line_height\}[\s\S]*\/>/u)
 		// Whitespace-normalized substring check avoids the long chain of `\s*` separators
 		// (SonarCloud rule typescript:S5852 flags such patterns as ReDoS candidates).
-		const normalized = BOARD_SOURCE.replace(/\s+/gu, ' ')
+		const normalized = BOARD_SOURCE.replaceAll(/\s+/gu, ' ')
 
 		expect(normalized).toContain(
 			'current_line_height = $derived( is_multiline_center ? MULTILINE_LINE_HEIGHT : SINGLE_LINE_HEIGHT',
@@ -177,7 +177,7 @@ describe('Board center label — START, ROUND digit, and 2-line GAME OVER', () =
 describe('templates Board mirrors the CRT-driven font behavior', () => {
 	it('derives should_use_alt_font from !crt.is_crt_enabled', () => {
 		expect(TEMPLATE_BOARD_SOURCE).toMatch(
-			/let\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
+			/(?:let|const)\s+should_use_alt_font\s*=\s*\$derived\(\s*!\s*crt\.is_crt_enabled\s*\)/u,
 		)
 	})
 

--- a/src/lib/game/Scene.svelte
+++ b/src/lib/game/Scene.svelte
@@ -14,7 +14,7 @@
 	const { start_z: CREDITS_SCROLL_START_Z, end_z: CREDITS_SCROLL_END_Z } =
 		make_credits_scroll_bounds(CREDITS_LINE_COUNT, HALF_D)
 
-	let score_data = $derived({
+	const score_data = $derived({
 		high_score: score.high_score,
 		current_score: score.current_score,
 		is_new_high_score: score.is_new_high_score,
@@ -22,7 +22,7 @@
 		last_cleared_round: score.last_cleared_round,
 		format_score: score.format_score,
 	})
-	let game_data = $derived({
+	const game_data = $derived({
 		active_color: game.active_color,
 		pressed_color: game.pressed_color,
 		phase: game.phase,
@@ -31,7 +31,7 @@
 		flash_intensity: game.flash_intensity,
 	})
 
-	let is_alt = $derived(game_state.is_alt)
+	const is_alt = $derived(game_state.is_alt)
 	const scene_messages: SceneObjectsMessages = {
 		game_title: messages.game_title,
 		alt_switch_label: messages.cyber_switch_label,

--- a/src/lib/vitest-examples/greet.ts
+++ b/src/lib/vitest-examples/greet.ts
@@ -1,3 +1,3 @@
 export function greet(name: string): string {
-	return 'Hello, ' + name + '!'
+	return `Hello, ${name}!`
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -37,7 +37,7 @@
 		if (bar) bar.value = loading.progress_value
 	})
 
-	let { children } = $props()
+	const { children } = $props()
 </script>
 
 <svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 		on_start: () => game.start(),
 	})
 
-	let hint_text = $derived(
+	const hint_text = $derived(
 		device.is_touch_primary ? messages.tap_to_start : messages.click_to_start,
 	)
 </script>

--- a/src/routes/e2e-helpers.ts
+++ b/src/routes/e2e-helpers.ts
@@ -10,7 +10,7 @@ export async function stub_touch_primary(page: Page, is_touch: boolean): Promise
 			globalThis.matchMedia = function patched(input: string): MediaQueryList {
 				if (input === query) {
 					return {
-						matches: matches as boolean,
+						matches,
 						media: input,
 						onchange: null,
 						addEventListener() {},

--- a/src/routes/page-features.e2e.ts
+++ b/src/routes/page-features.e2e.ts
@@ -164,7 +164,7 @@ test('favicon link points to the game icon, not the Svelte logo', async ({ page 
 	await page.goto('/')
 	const icon_href = await page.evaluate(() => {
 		const links = document.querySelectorAll<HTMLLinkElement>('link[rel="icon"]')
-		const last = links[links.length - 1]
+		const last = [...links].at(-1)
 
 		return last?.getAttribute('href') ?? null
 	})


### PR DESCRIPTION
## Scope

**PR-6 of multi-PR migration** addressing #188 (continues PR-5 #194). Largest single batch of the series — enables 22 auto-fixable rules at once.

## Rules enabled

| Rule | Approach |
|---|---|
| `prefer-const` | --fix (let→const for never-reassigned) |
| `unicorn/better-regex` | --fix (simplify regex literals) |
| `unicorn/prefer-spread` | --fix |
| `unicorn/prefer-string-raw` | --fix |
| `unicorn/consistent-existence-index-check` | --fix |
| `unicorn/prefer-dom-node-append` | --fix |
| `@typescript-eslint/no-unnecessary-type-assertion` | --fix |
| `unicorn/no-zero-fractions` | --fix |
| `curly` | --fix |
| `unicorn/no-array-for-each` | --fix |
| `@typescript-eslint/no-inferrable-types` | --fix |
| `unicorn/prefer-number-properties` | --fix |
| `lines-between-class-members` | --fix |
| `unicorn/require-module-specifiers` | --fix |
| `@typescript-eslint/consistent-type-imports` | --fix |
| `unicorn/prefer-global-this` | --fix |
| `unicorn/prefer-modern-math-apis` | --fix |
| `prefer-exponentiation-operator` | --fix |
| `unicorn/prefer-switch` | --fix |
| `@typescript-eslint/method-signature-style` | --fix |
| `@typescript-eslint/no-useless-default-assignment` | --fix |
| `unicorn/prefer-string-replace-all` | --fix |
| `prefer-template` | --fix |
| `unicorn/prefer-at` | --fix |

## Rules KEPT disabled (known dangerous)

| Rule | Reason (verified in pre-PR-1 baseline) |
|---|---|
| `prefer-arrow-callback` | Rewrites `function () {}` → `() => {}` which breaks `new`-constructibility — Audio mock regression |
| `unicorn/no-useless-undefined` | Strips required-by-signature `undefined` args — broke `vi.stubGlobal` / `mockResolvedValue` |
| `dot-notation` | Converts bracket-access to dot-access, but TS index-signature types REQUIRE bracket access — broke `u_res` |
| `unicorn/number-literal-case` | Wants uppercase hex (`0x9E`) but prettier normalizes to lowercase (`0x9e`) — unresolvable lint↔format conflict |

These 4 stay disabled with explanatory comments referencing the conflicts. All other safe auto-fixable rules in the backlog are now removed.

## Regression fixes within this PR

`prefer-const` flipped many source `let` declarations to `const`, breaking source-shape regex assertions in 6 test files. Updated those tests:
- Updated `let\\s+` regex patterns to `(?:let|const)\\s+` in: `Board.svelte.test.ts`, `GameScene.svelte.test.ts`, `ScoreDisplay.svelte.test.ts`, `ControlsScene.svelte.test.ts`, `FloorCredits.svelte.test.ts`, `SceneObjects.svelte.test.ts`
- Restored `[...links].at(-1)` in `page-features.e2e.ts` (a fix that had been reverted in main; `NodeListOf` doesn't have `.at()`)

## Verification

- All gates green: lint, tsc, cspell, unit (1065 tests)
- 48 files modified, 239 insertions / 265 deletions

This PR partially addresses **#188**; **#188 stays open** (remaining disables are 4 dangerous-autofix + ~50 manual-fix categories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)