### PR TITLE
PR-10 of strict eslint migration: configure import/extensions allowList for js/json/opus/svelte #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,8 +32,6 @@ const PR1_TEMPORARY_RULE_DISABLES = {
 	'sonarjs/no-duplicate-string': 'off',
 	// TODO #188 follow-up: align identifier names with snake_case / boolean prefix rules
 	'@typescript-eslint/naming-convention': 'off',
-	// TODO #188 follow-up: configure import/extensions allowList for Three.js .js deep imports + package.json + SvelteKit hooks.server (rule auto-fix is no-op; needs allowList in rule config — deferred for human review)
-	'import/extensions': 'off',
 	// TODO #188 follow-up: rename files to PascalCase for Svelte components / `.svelte.ts`
 	'unicorn/filename-case': 'off',
 	// TODO #188 follow-up: add explicit return types to exported functions
@@ -131,8 +129,29 @@ const PR1_TEMPORARY_RULE_DISABLES = {
 // templates so they can be linted from this repo).
 const PR1_TEMPORARY_FILE_IGNORES = ['scripts/**', 'templates/**']
 
+// Explicit per-extension overrides for `import/extensions` (PR-10 of #188).
+// The base rule mode is `'never'` (drop extensions) but these legitimate cases
+// require / benefit from keeping the extension visible:
+// - `.js` — Three.js deep imports (`three/examples/jsm/postprocessing/*.js`)
+//   require the explicit `.js` per the package's exports map
+// - `.json` — JSON imports (e.g. `../package.json`) need the extension so the
+//   module resolver classifies them as JSON, not TypeScript
+// - `.opus` — Vite resolves asset URLs by extension; dropping it breaks the
+//   bundler's import-to-URL transformation
+const IMPORT_EXTENSIONS_OVERRIDES = {
+	'import/extensions': [
+		'error',
+		'never',
+		{ js: 'always', json: 'always', opus: 'always', svelte: 'always' },
+	],
+}
+
 export default create_sveltekit_config({
 	gitignore_path: new URL('./.gitignore', import.meta.url),
 	tsconfig_root_dir: import.meta.dirname,
 	svelte_config: svelteConfig,
-}).concat({ ignores: PR1_TEMPORARY_FILE_IGNORES }, { rules: PR1_TEMPORARY_RULE_DISABLES })
+}).concat(
+	{ ignores: PR1_TEMPORARY_FILE_IGNORES },
+	{ rules: PR1_TEMPORARY_RULE_DISABLES },
+	{ rules: IMPORT_EXTENSIONS_OVERRIDES },
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.86.0",
+	"version": "0.87.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import type { RequestEvent, ResolveOptions } from '@sveltejs/kit'
 import { describe, expect, it, vi } from 'vitest'
+// eslint-disable-next-line import/extensions -- `hooks.server` is a SvelteKit-mandated multi-part filename, not an extension
 import { handle, inject_game_name, inject_version } from './hooks.server'
 
 const { version } = JSON.parse(


### PR DESCRIPTION
## Scope

**PR-10 of multi-PR migration** addressing #188 (continues PR-9 #198).

Removes `'import/extensions': 'off'` from the [eslint.config.js](eslint.config.js) backlog. **All 33 violations resolved via rule configuration — zero source-file changes** (except 1 inline disable for a false-positive).

## Approach

Configured `import/extensions` with explicit per-extension overrides:

```js
'import/extensions': ['error', 'never', {
  js: 'always',     // Three.js deep imports (three/examples/jsm/postprocessing/*.js)
  json: 'always',   // JSON imports (package.json)
  opus: 'always',   // Vite asset URLs (sound files)
  svelte: 'always', // Svelte components (.svelte is mandatory)
}]
```

Each entry explained inline. The one remaining violation is `./hooks.server` — SvelteKit treats `.server` as part of the filename (per its routing convention), not as an extension. Per-line `eslint-disable-next-line` with explanation.

## Verification

- All gates green
- 2 files changed: eslint.config.js (+22 / -3) + 1 inline disable

This PR partially addresses **#188**; **#188 stays open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)