### PR TITLE
Layer C-3: enable 16 small-count rules + sonarjs/no-use-of-empty-return-value permanent disable (Svelte @render false positive) #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,10 @@ const LAYER_B_DISABLES = {
 	// `dot-notation` converts bracket access to dot access, but TS index-signature
 	// types REQUIRE bracket access. Always disabled.
 	'dot-notation': 'off',
+	// `sonarjs/no-use-of-empty-return-value` fires on Svelte `{@render snippet()}` —
+	// the rule treats the snippet call as a value-consuming expression, but `@render`
+	// is a template directive. Per-line disables on every snippet site is noisier.
+	'sonarjs/no-use-of-empty-return-value': 'off',
 
 	// === Layer C follow-up (high-volume manual refactor) ===
 	'id-length': 'off',
@@ -35,24 +39,8 @@ const LAYER_B_DISABLES = {
 	'no-bitwise': 'off',
 	complexity: 'off',
 	'@typescript-eslint/consistent-type-assertions': 'off',
-	'no-duplicate-imports': 'off',
-	'max-params': 'off',
-	'sonarjs/pseudo-random': 'off',
 	'@typescript-eslint/unbound-method': 'off',
-	'no-multi-assign': 'off',
-	'no-console': 'off',
 	'max-lines': 'off',
-	'sonarjs/no-use-of-empty-return-value': 'off',
-	'unicorn/consistent-function-scoping': 'off',
-	'@typescript-eslint/no-unsafe-call': 'off',
-	'sonarjs/no-commented-code': 'off',
-	'@typescript-eslint/no-restricted-imports': 'off',
-	'require-atomic-updates': 'off',
-	'promise/prefer-await-to-then': 'off',
-	'consistent-return': 'off',
-	'no-plusplus': 'off',
-	'default-case': 'off',
-	'unicorn/no-array-reverse': 'off',
 	'unicorn/prevent-abbreviations': 'off',
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.92.0",
+	"version": "0.93.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,11 +1,5 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare global {
-	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
-	}
+	namespace App {}
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import type { Handle } from '@sveltejs/kit'
 import { GAME_NAME, GAME_NAME_DISPLAY } from '$lib/game/game-name'
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- reading own package.json version is the standard SvelteKit pattern for app-version injection
 import { version } from '../package.json'
 
 const APP_VERSION_PLACEHOLDER = '__APP_VERSION__'

--- a/src/lib/game-kit/Fullscreen.svelte.ts
+++ b/src/lib/game-kit/Fullscreen.svelte.ts
@@ -52,6 +52,7 @@ function update_native_flag(s: FullscreenState): void {
 async function request_fullscreen(s: FullscreenState, element: HTMLElement): Promise<void> {
 	if (s.is_native_fullscreen || s.is_pseudo_fullscreen) return
 	const did_succeed = await call_native_request(element)
+	// eslint-disable-next-line require-atomic-updates -- `s.is_pseudo_fullscreen` is read once at entry, awaited, then assigned. There is no concurrent caller (single-user fullscreen state machine).
 	if (!did_succeed) s.is_pseudo_fullscreen = true
 }
 
@@ -75,6 +76,7 @@ export function create_fullscreen() {
 	let manager: ListenerManager | null = null
 
 	function setup_listeners(): () => void {
+		// eslint-disable-next-line no-multi-assign -- `(manager ??= ...)` is the idiomatic lazy-init pattern
 		const m = (manager ??= create_listener_manager([
 			{ target: document, type: 'fullscreenchange', handler },
 			{ target: document, type: 'webkitfullscreenchange', handler },

--- a/src/lib/game-kit/GameScene.svelte
+++ b/src/lib/game-kit/GameScene.svelte
@@ -16,8 +16,7 @@
 	import { session } from '$lib/game-kit/Session.svelte'
 	import { game_state } from '$lib/game-kit/State.svelte'
 	import { fullscreen_switch_input } from '$lib/game-kit/switch/fullscreen-switch-input'
-	import type { Snippet } from 'svelte'
-	import { onMount } from 'svelte'
+	import { onMount, type Snippet } from 'svelte'
 	import { WebGLRenderer } from 'three'
 
 	// DPR is calibrated so the shorter buffer edge targets TARGET_SHORT_EDGE_PIXELS for
@@ -135,6 +134,7 @@
 		const canvas_element = container.querySelector<HTMLCanvasElement>('canvas')
 
 		if (!canvas_element) {
+			// eslint-disable-next-line no-console -- console.warn is the standard diagnostic channel for missing-DOM warnings; not a candidate for a logger
 			console.warn('[GameScene] No <canvas> found at mount — synthetic pointer events disabled')
 		}
 

--- a/src/lib/game-kit/GameScene.svelte.test.ts
+++ b/src/lib/game-kit/GameScene.svelte.test.ts
@@ -104,6 +104,7 @@ describe('GameScene', () => {
 		let call_count = 0
 		const { container } = render_scene({
 			on_start: () => {
+				// eslint-disable-next-line no-plusplus -- idiomatic counter increment inside a test callback
 				call_count++
 			},
 		})

--- a/src/lib/game-kit/audio.ts
+++ b/src/lib/game-kit/audio.ts
@@ -7,6 +7,7 @@ function init_audio(): void {
 }
 
 function get_audio_context(): AudioContext | null {
+	// eslint-disable-next-line promise/prefer-await-to-then -- fire-and-forget; making this async would require awaiting at every audio call site
 	if (context?.state === 'suspended') void context.resume().catch(() => {})
 
 	return context

--- a/src/lib/game-kit/controls/ControlsScene.svelte
+++ b/src/lib/game-kit/controls/ControlsScene.svelte
@@ -225,6 +225,7 @@
 				mouse_tex = ms
 				touch_tex = tc
 			} catch (error) {
+				// eslint-disable-next-line no-console -- console.warn is the standard diagnostic channel for non-fatal asset load failures
 				console.warn('[ControlsScene] failed to load control hint textures', error)
 			}
 		})()

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte
@@ -197,7 +197,8 @@
 	}
 
 	onMount(() => {
-		if (!('ontouchstart' in globalThis)) return
+		if (!('ontouchstart' in globalThis)) return () => {}
+
 		move_zone.addEventListener('touchstart', on_move_start, { passive: false })
 		look_zone.addEventListener('touchstart', on_look_start, { passive: false })
 		document.addEventListener('touchmove', on_touch_move, { passive: false })

--- a/src/lib/game-kit/crt-dither.test.ts
+++ b/src/lib/game-kit/crt-dither.test.ts
@@ -248,6 +248,7 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 		// VGA 3-3-2 gives blue half the levels of red/green (8/8/4). Lock in that asymmetry
 		// here so any accidental return to uniform per-channel levels (e.g. { r: 16, g: 16, b: 16 })
 		// fails this guard at the COLOR_LEVELS change point.
+		// eslint-disable-next-line unicorn/consistent-function-scoping -- test helper scoped to this assertion block for clarity
 		function distinct_outputs(levels: number): number {
 			const seen = new Set<number>()
 
@@ -420,6 +421,7 @@ describe('ShaderPass uniform binding (CrtDitherPass regression)', () => {
 	const TRIVIAL_VERTEX_SHADER = 'void main(){ gl_Position = vec4(position, 1.0); }'
 	const TRIVIAL_FRAGMENT_SHADER = 'void main(){ gl_FragColor = vec4(1.0); }'
 
+	// eslint-disable-next-line unicorn/consistent-function-scoping -- test helper scoped to the ShaderPass describe block
 	function get_uniform_vec2(pass: ShaderPass): Vector2 {
 		const slot = pass.uniforms['u_res']
 		if (!slot) throw new Error('u_res uniform missing on pass')

--- a/src/lib/game-kit/display/FpsDisplay.svelte
+++ b/src/lib/game-kit/display/FpsDisplay.svelte
@@ -16,6 +16,7 @@
 			return
 		}
 
+		// eslint-disable-next-line no-plusplus -- frame counter in render loop; `+= 1` is busier here
 		frame_count++
 		const now = performance.now()
 		const elapsed = now - last_time

--- a/src/lib/game-kit/input/Input.svelte.ts
+++ b/src/lib/game-kit/input/Input.svelte.ts
@@ -141,16 +141,12 @@ function on_left_mouse_for_synth_impl(
 		}
 
 		case 'mouseup': {
-			{
-				dispatch_synthetic_pointer(
-					'pointerup',
-					s.drag_start_x,
-					s.drag_start_y,
-					references.canvas_el,
-				)
-				// No default
-			}
+			dispatch_synthetic_pointer('pointerup', s.drag_start_x, s.drag_start_y, references.canvas_el)
+			break
+		}
 
+		default: {
+			// No-op for unhandled event types (the function is wired to mousedown/mouseup only).
 			break
 		}
 	}
@@ -322,6 +318,7 @@ function make_input_api(s: InputState, jm: Vec2, jl: Vec2, references: InputRefe
 			return jl
 		},
 		setup_listeners: (canvas_element: HTMLCanvasElement | null): (() => void) => {
+			// eslint-disable-next-line no-multi-assign -- idiomatic lazy-init `??=` pattern
 			const m = (manager ??= create_listener_manager(make_listener_specs(s, references)))
 			if (!m.is_active || canvas_element !== null) references.canvas_el = canvas_element
 

--- a/src/lib/game-kit/input/joystick-dispatch.ts
+++ b/src/lib/game-kit/input/joystick-dispatch.ts
@@ -52,6 +52,7 @@ function dispatch_pointer_down(
 	context.dom.dispatchEvent(down_event)
 }
 
+// eslint-disable-next-line max-params -- coordinate-rich pointer dispatch; object-arg shape adds noise at call sites
 function dispatch_pointer_up(
 	pointer_id: number,
 	is_primary: boolean,

--- a/src/lib/game-kit/pixel-dpr.ts
+++ b/src/lib/game-kit/pixel-dpr.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-params -- viewport-rendering math signature with 6 numeric tuning params; object-arg shape adds noise at call sites
 function compute_pixel_dpr(
 	viewport_w: number,
 	viewport_h: number,

--- a/src/lib/game-kit/player/CameraShake.svelte.ts
+++ b/src/lib/game-kit/player/CameraShake.svelte.ts
@@ -16,7 +16,8 @@ function reset(): void {
 function sample(max: number): number {
 	if (intensity <= 0) return 0
 
-	return (Math.random() * 2 - 1) * max * intensity // NOSONAR — visual animation only
+	// eslint-disable-next-line sonarjs/pseudo-random -- visual camera shake; not security-sensitive
+	return (Math.random() * 2 - 1) * max * intensity
 }
 
 function step(delta: number): void {

--- a/src/lib/game-kit/scene/credits-config.ts
+++ b/src/lib/game-kit/scene/credits-config.ts
@@ -20,6 +20,7 @@ export function make_credits_scroll_bounds(
 	return { start_z: offset, end_z: -offset }
 }
 
+// eslint-disable-next-line max-params -- scrolling math signature with 5 numeric params; object-arg shape adds noise at call sites
 export function advance_scroll(
 	current_z: number,
 	delta: number,

--- a/src/lib/game-kit/switch/Switch.svelte
+++ b/src/lib/game-kit/switch/Switch.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
 	import { T } from '@threlte/core'
 	import { Text } from '@threlte/extras'
-	import { resolve_switch_colors } from '$lib/game-kit/switch/switch-colors'
-	import type { SwitchColors } from '$lib/game-kit/switch/switch-colors'
-	import type { SwitchGeometry, SwitchIconType } from '$lib/game-kit/switch/switch-config'
+	import { resolve_switch_colors, type SwitchColors } from '$lib/game-kit/switch/switch-colors'
 	import {
 		DEFAULT_SWITCH_GEOMETRY,
 		FPS_BAR_1_H,
@@ -11,6 +9,8 @@
 		FPS_BAR_3_H,
 		FPS_BAR_BASE_Y,
 		FPS_BAR_X_STEP,
+		type SwitchGeometry,
+		type SwitchIconType,
 	} from '$lib/game-kit/switch/switch-config'
 	import { onDestroy } from 'svelte'
 	import { MeshStandardMaterial } from 'three'

--- a/src/lib/game/Board.svelte.test.ts
+++ b/src/lib/game/Board.svelte.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- testing parity between src/ and templates/; intentional cross-tree read
 import TEMPLATE_BOARD_SOURCE from '../../../templates/src/lib/game/Board.svelte?raw'
 import Board from './Board.svelte'
 import BOARD_SOURCE from './Board.svelte?raw'

--- a/src/lib/game/Game.svelte.ts
+++ b/src/lib/game/Game.svelte.ts
@@ -44,7 +44,8 @@ function get_step_ms(length_: number): number {
 }
 
 function add_to_sequence(s: GameState, colors: ReadonlyArray<ButtonColor>): void {
-	const index = Math.floor(Math.random() * colors.length) // NOSONAR — game RNG, not security-sensitive
+	// eslint-disable-next-line sonarjs/pseudo-random -- game RNG; not security-sensitive
+	const index = Math.floor(Math.random() * colors.length)
 
 	s.sequence.push(colors[index] ?? FALLBACK_COLOR)
 }

--- a/src/lib/game/Score.svelte.test.ts
+++ b/src/lib/game/Score.svelte.test.ts
@@ -333,6 +333,7 @@ describe('legacy simon_* migration', () => {
 		vi.unstubAllGlobals()
 	})
 
+	// eslint-disable-next-line unicorn/consistent-function-scoping -- test helper scoped to the migration describe block
 	function stub_legacy_only(store: Record<string, string>): { set_calls: Array<[string, string]> } {
 		const set_calls: Array<[string, string]> = []
 

--- a/src/lib/game/flash.ts
+++ b/src/lib/game/flash.ts
@@ -70,7 +70,7 @@ async function flash_cascade(
 		await delay(FLASH_CASCADE_FWD_MS)
 	}
 
-	for (const color of [...colors].reverse()) {
+	for (const color of colors.toReversed()) {
 		if (t.flash_gen !== gen) return
 		s.flash_colors = [color]
 		s.flash_intensity = FLASH_INTENSITY_BURST

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,4 +43,5 @@
 <svelte:head>
 	<title>{messages.game_title}</title>
 </svelte:head>
+<!-- eslint-disable-next-line @typescript-eslint/no-unsafe-call -->
 {@render children()}


### PR DESCRIPTION
## Scope

**Layer C-3** of #188. Enables 16 small-count rules from `LAYER_B_DISABLES` (~28 violations); adds 1 permanent disable for a Svelte-template false positive.

## Real fixes

| Site | Fix |
|---|---|
| `src/app.d.ts` | Strip placeholder comments (`sonarjs/no-commented-code`) |
| `src/lib/game/flash.ts` | `[...colors].reverse()` → `colors.toReversed()` |
| `src/lib/game-kit/GameScene.svelte` | Merge duplicate `'svelte'` imports |
| `src/lib/game-kit/switch/Switch.svelte` | Merge duplicate switch-colors/switch-config imports |
| `src/lib/game-kit/input/Input.svelte.ts` | Add `default` branch to switch on `e.type` |
| `src/lib/game-kit/controls/VirtualJoystick.svelte` | Return `() => {}` from `onMount` early-exit to satisfy `consistent-return` |

## Inline disables (idiomatic patterns)

| Site | Rule | Rationale |
|---|---|---|
| `src/hooks.server.ts` | `no-restricted-imports` | Reading own `package.json` for version injection is the standard SvelteKit pattern |
| `src/lib/game-kit/Fullscreen.svelte.ts` ×2 | `require-atomic-updates`, `no-multi-assign` | Single-user state machine; `??=` is idiomatic lazy-init |
| `src/lib/game-kit/audio.ts` | `promise/prefer-await-to-then` | Fire-and-forget `.catch(() => {})`; await would force every call site async |
| `src/lib/game-kit/GameScene.svelte` ×2 | `no-console`, `no-multi-assign` | `console.warn` is the standard diagnostic channel; `??=` lazy-init |
| `src/lib/game-kit/controls/ControlsScene.svelte` | `no-console` | Diagnostic for asset load failures |
| `src/lib/game-kit/display/FpsDisplay.svelte` | `no-plusplus` | Frame-counter in render loop |
| `src/lib/game-kit/GameScene.svelte.test.ts` | `no-plusplus` | Test callback counter |
| `src/lib/game-kit/input/Input.svelte.ts` | `no-multi-assign` | `??=` lazy-init |
| `src/lib/game-kit/input/joystick-dispatch.ts` | `max-params` | Coordinate-rich pointer dispatch (5 params) |
| `src/lib/game-kit/pixel-dpr.ts` | `max-params` | Viewport math with 6 tuning params |
| `src/lib/game-kit/scene/credits-config.ts` | `max-params` | Scrolling math with 5 numeric params |
| `src/lib/game-kit/player/CameraShake.svelte.ts` | `sonarjs/pseudo-random` | Visual shake; not security-sensitive |
| `src/lib/game/Game.svelte.ts` | `sonarjs/pseudo-random` | Game RNG; not security-sensitive |
| `src/lib/game-kit/crt-dither.test.ts` ×2 | `unicorn/consistent-function-scoping` | Test helpers scoped to describe block |
| `src/lib/game/Score.svelte.test.ts` | `unicorn/consistent-function-scoping` | Test helper scoped to describe block |
| `src/lib/game/Board.svelte.test.ts` | `no-restricted-imports` | Intentional cross-tree parity test |
| `src/routes/+layout.svelte` | `no-unsafe-call` | Svelte auto-typed slot snippet untraceable in type system |

## Permanent disable added

`sonarjs/no-use-of-empty-return-value` — fires on `{@render snippet()}` because the rule treats snippet calls as value-consuming expressions, but `@render` is a template directive. Per-line disables on every snippet site is noisier.

## Verification

- All gates green
- 22 files changed
- Disable count: 37 → 21 (−16 rules)

**#188 stays open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)