### PR TITLE
Layer C-4: enable no-bitwise + unbound-method + consistent-type-assertions + project-wide prevent-abbreviations allowList (with e2e) #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,12 +36,8 @@ const LAYER_B_DISABLES = {
 	'sonarjs/cognitive-complexity': 'off',
 	'@typescript-eslint/restrict-template-expressions': 'off',
 	'@typescript-eslint/no-unnecessary-condition': 'off',
-	'no-bitwise': 'off',
 	complexity: 'off',
-	'@typescript-eslint/consistent-type-assertions': 'off',
-	'@typescript-eslint/unbound-method': 'off',
 	'max-lines': 'off',
-	'unicorn/prevent-abbreviations': 'off',
 }
 
 // `scripts/` and `templates/` are not in any tsconfig project here:
@@ -51,8 +47,37 @@ const LAYER_B_DISABLES = {
 // Tracked as Layer C follow-up (add a scripts tsconfig; restructure templates).
 const FILE_IGNORES = ['scripts/**', 'templates/**']
 
+// Kit 0.189 ships `unicorn/prevent-abbreviations` allowList inside SVELTE_FILE_PATTERNS.svelte,
+// but plain `.ts` files (non-Svelte) don't inherit it. Re-apply the same allowList project-wide
+// so idiomatic short names (e, el, ctx, btn, idx, etc.) don't fire in CLI helpers, hash utilities,
+// or e2e tests. Also adds `e2e` so Playwright filename convention (page.e2e.ts) doesn't get
+// expanded to absurd `page.error2error.ts`.
+const PREVENT_ABBREVIATIONS_OVERRIDE = {
+	'unicorn/prevent-abbreviations': [
+		'error',
+		{
+			allowList: {
+				Props: true,
+				e: true,
+				e2e: true,
+				el: true,
+				ctx: true,
+				btn: true,
+				idx: true,
+				opts: true,
+				params: true,
+				args: true,
+			},
+		},
+	],
+}
+
 export default create_sveltekit_config({
 	gitignore_path: new URL('./.gitignore', import.meta.url),
 	tsconfig_root_dir: import.meta.dirname,
 	svelte_config: svelteConfig,
-}).concat({ ignores: FILE_IGNORES }, { rules: LAYER_B_DISABLES })
+}).concat(
+	{ ignores: FILE_IGNORES },
+	{ rules: LAYER_B_DISABLES },
+	{ rules: PREVENT_ABBREVIATIONS_OVERRIDE },
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.93.0",
+	"version": "0.94.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -14,6 +14,11 @@ function make_resolve(): ResolveFunction {
 	return vi.fn<ResolveFunction>().mockResolvedValue(new Response(null, { status: 200 }))
 }
 
+// `handle()` does not read event fields in the header-injection tests; minimal empty mock with a single
+// type-assertion is intentional. Avoids 6 inline disables at every test call site.
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- empty-mock pattern; `const x: RequestEvent = {}` won't type-check
+const MOCK_EVENT = {} as RequestEvent
+
 describe('inject_game_name', () => {
 	it('replaces __GAME_NAME__ with the all-caps game name', () => {
 		const html = '<p class="game-title">__GAME_NAME__</p>'
@@ -62,25 +67,25 @@ describe('inject_version', () => {
 
 describe('handle', () => {
 	it('adds X-Frame-Options: SAMEORIGIN', async () => {
-		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+		const response = await handle({ event: MOCK_EVENT, resolve: make_resolve() })
 
 		expect(response.headers.get('x-frame-options')).toBe('SAMEORIGIN')
 	})
 
 	it('adds X-Content-Type-Options: nosniff', async () => {
-		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+		const response = await handle({ event: MOCK_EVENT, resolve: make_resolve() })
 
 		expect(response.headers.get('x-content-type-options')).toBe('nosniff')
 	})
 
 	it('adds Referrer-Policy: strict-origin-when-cross-origin', async () => {
-		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+		const response = await handle({ event: MOCK_EVENT, resolve: make_resolve() })
 
 		expect(response.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin')
 	})
 
 	it('adds Permissions-Policy restricting camera, microphone, geolocation, payment', async () => {
-		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+		const response = await handle({ event: MOCK_EVENT, resolve: make_resolve() })
 		const policy = response.headers.get('permissions-policy')
 
 		expect(policy).toContain('camera=()')
@@ -90,7 +95,7 @@ describe('handle', () => {
 	})
 
 	it("adds Content-Security-Policy with default-src 'self'", async () => {
-		const response = await handle({ event: {} as RequestEvent, resolve: make_resolve() })
+		const response = await handle({ event: MOCK_EVENT, resolve: make_resolve() })
 		const csp = response.headers.get('content-security-policy')
 
 		expect(csp).toContain("default-src 'self'")
@@ -108,7 +113,7 @@ describe('handle', () => {
 			return Promise.resolve(new Response(null, { status: 200 }))
 		})
 
-		await handle({ event: {} as RequestEvent, resolve })
+		await handle({ event: MOCK_EVENT, resolve })
 		const result = await captured_transform?.({ html: 'v__APP_VERSION__', done: true })
 
 		expect(result).toBe(`v${version}`)

--- a/src/lib/game-kit/Fullscreen.svelte.ts
+++ b/src/lib/game-kit/Fullscreen.svelte.ts
@@ -21,6 +21,7 @@ function get_native_fullscreen_element(): Element | null {
 }
 
 async function call_native_request(element: HTMLElement): Promise<boolean> {
+	// eslint-disable-next-line @typescript-eslint/unbound-method -- explicit .call(element) below preserves the `this` binding
 	const function_ = element.requestFullscreen ?? element.webkitRequestFullscreen
 	if (typeof function_ !== 'function') return false
 
@@ -34,6 +35,7 @@ async function call_native_request(element: HTMLElement): Promise<boolean> {
 }
 
 async function call_native_exit(): Promise<void> {
+	// eslint-disable-next-line @typescript-eslint/unbound-method -- explicit .call(document) below preserves the `this` binding
 	const function_ = document.exitFullscreen ?? document.webkitExitFullscreen
 	if (typeof function_ !== 'function') return
 

--- a/src/lib/game-kit/input/PointerCompute.svelte.test.ts
+++ b/src/lib/game-kit/input/PointerCompute.svelte.test.ts
@@ -68,6 +68,7 @@ describe('make_pointer_compute', () => {
 
 		expect(context.pointer.current.x).toBeCloseTo(CENTER)
 		expect(context.pointer.current.y).toBeCloseTo(CENTER)
+		// eslint-disable-next-line @typescript-eslint/unbound-method -- vitest spy assertion; the .toHaveBeenCalled matcher handles `this` correctly
 		expect(context.raycaster.setFromCamera).toHaveBeenCalledWith(
 			context.pointer.current,
 			camera.current,
@@ -97,6 +98,7 @@ describe('make_pointer_compute', () => {
 
 		expect(context.pointer.current.x).toBe(0.5)
 		expect(context.pointer.current.y).toBe(0.5)
+		// eslint-disable-next-line @typescript-eslint/unbound-method -- vitest spy assertion; the .toHaveBeenCalled matcher handles `this` correctly
 		expect(context.raycaster.setFromCamera).not.toHaveBeenCalled()
 	})
 
@@ -111,6 +113,7 @@ describe('make_pointer_compute', () => {
 
 		expect(context.pointer.current.x).toBe(0.5)
 		expect(context.pointer.current.y).toBe(0.5)
+		// eslint-disable-next-line @typescript-eslint/unbound-method -- vitest spy assertion; the .toHaveBeenCalled matcher handles `this` correctly
 		expect(context.raycaster.setFromCamera).not.toHaveBeenCalled()
 	})
 })

--- a/src/lib/game/Score.svelte.ts
+++ b/src/lib/game/Score.svelte.ts
@@ -30,6 +30,7 @@ interface RoundData {
 }
 
 export function compute_check(value: number, round: number): number {
+	// eslint-disable-next-line no-bitwise -- score-tamper-check hash; bitwise XOR and unsigned-shift are intentional
 	return (Math.imul(value + 1, CHECK_SEED) ^ Math.imul(round + 1, CHECK_SEED >>> 1)) >>> 0
 }
 

--- a/src/routes/e2e-helpers.ts
+++ b/src/routes/e2e-helpers.ts
@@ -9,6 +9,7 @@ export async function stub_touch_primary(page: Page, is_touch: boolean): Promise
 
 			globalThis.matchMedia = function patched(input: string): MediaQueryList {
 				if (input === query) {
+					// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial-mock pattern; literal would need every MediaQueryList field
 					return {
 						matches,
 						media: input,

--- a/src/routes/page-features.e2e.ts
+++ b/src/routes/page-features.e2e.ts
@@ -113,10 +113,12 @@ test('page has no critical or serious accessibility violations', async ({ page }
 })
 
 test('high score persists in localStorage across page reload', async ({ page }) => {
+	/* eslint-disable no-bitwise -- score-tamper-check hash; mirrors src/lib/game/Score.svelte.ts compute_check */
 	const stored_check =
 		(Math.imul(SAMPLE_HIGH_SCORE + 1, CHECK_SEED) ^
 			Math.imul(SAMPLE_HIGH_ROUND + 1, CHECK_SEED >>> 1)) >>>
 		0
+	/* eslint-enable no-bitwise */
 
 	await page.goto('/')
 	await page.evaluate(


### PR DESCRIPTION
## Scope

**Layer C-4** of #188. Enables 4 more rules from `LAYER_B_DISABLES`.

## Rules enabled

| Rule | Violations | Strategy |
|---|---|---|
| `no-bitwise` | 6 | Inline disable on the 2 score-tamper-check hash sites (Score.svelte.ts, page-features.e2e.ts); block-disable for the multi-line e2e hash |
| `@typescript-eslint/unbound-method` | 5 | Inline disable for `.call(element)` explicit-this patterns (Fullscreen.svelte.ts) and vitest `.toHaveBeenCalled` spy assertions (PointerCompute.svelte.test.ts) |
| `@typescript-eslint/consistent-type-assertions` | 7 | Refactored 6 `{} as RequestEvent` call sites into a shared `MOCK_EVENT` constant; inline disable for the partial-mock pattern (e2e-helpers.ts MediaQueryList mock) |
| `unicorn/prevent-abbreviations` | 9 | New project-wide allowList override (covers `e`, `el`, `ctx`, `btn`, `idx`, `opts`, `params`, `args`, `Props`, `e2e`) |

## kit#418 follow-up: project-wide override

Kit 0.189's `unicorn/prevent-abbreviations` allowList is scoped to `SVELTE_FILE_PATTERNS.svelte_named` (only `.svelte`/`.svelte.ts`/`.svelte.test.ts`). Plain `.ts` files (CLI helpers, hash utilities, e2e tests) don't inherit it. Added a project-local override that extends the same allowList project-wide, plus `e2e` so Playwright filenames (`page.e2e.ts`) don't trigger absurd `page.error2error.ts` suggestions.

This could be upstreamed to kit (similar to kit#418) but the project-local form is fine for now.

## Verification

- All gates green
- 7 files changed
- Disable count: 21 → 17 (−4 rules)

**#188 stays open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)