### PR TITLE
Layer C-6: enable restrict-template-expressions + no-unnecessary-condition #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,8 +32,6 @@ const LAYER_B_DISABLES = {
 	'@typescript-eslint/no-empty-function': 'off',
 	'sonarjs/no-duplicate-string': 'off',
 	'sonarjs/cognitive-complexity': 'off',
-	'@typescript-eslint/restrict-template-expressions': 'off',
-	'@typescript-eslint/no-unnecessary-condition': 'off',
 	complexity: 'off',
 	'max-lines': 'off',
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.95.0",
+	"version": "0.96.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -5,7 +5,7 @@
 	function generate_filter_id(): string {
 		next_filter_id += 1
 
-		return `${FILTER_ID_PREFIX}-${next_filter_id}`
+		return `${FILTER_ID_PREFIX}-${String(next_filter_id)}`
 	}
 </script>
 

--- a/src/lib/game-kit/Device.svelte.ts
+++ b/src/lib/game-kit/Device.svelte.ts
@@ -5,7 +5,12 @@ interface Device {
 }
 
 export function create_device(): Device {
-	const mql = globalThis.matchMedia?.(TOUCH_PRIMARY_QUERY) ?? null
+	// `typeof === 'function'` (not optional chaining) so TS sees the genuine
+	// `MediaQueryList | null` union — matchMedia is absent under SSR / Node test envs,
+	// even though lib.dom types it as always present. Covers both "missing" and
+	// "present but undefined" (e.g. vi.stubGlobal('matchMedia', undefined)).
+	const mql =
+		typeof globalThis.matchMedia === 'function' ? globalThis.matchMedia(TOUCH_PRIMARY_QUERY) : null
 	let is_touch = $state(mql?.matches ?? false)
 
 	mql?.addEventListener('change', (e: MediaQueryListEvent) => {

--- a/src/lib/game-kit/Fullscreen.svelte.ts
+++ b/src/lib/game-kit/Fullscreen.svelte.ts
@@ -21,8 +21,9 @@ function get_native_fullscreen_element(): Element | null {
 }
 
 async function call_native_request(element: HTMLElement): Promise<boolean> {
-	// eslint-disable-next-line @typescript-eslint/unbound-method -- explicit .call(element) below preserves the `this` binding
-	const function_ = element.requestFullscreen ?? element.webkitRequestFullscreen
+	const function_ =
+		// eslint-disable-next-line @typescript-eslint/unbound-method, @typescript-eslint/no-unnecessary-condition -- .call(element) below binds `this`; webkit fallback is absent in lib.dom types but real on older Safari
+		element.requestFullscreen ?? element.webkitRequestFullscreen
 	if (typeof function_ !== 'function') return false
 
 	try {
@@ -35,8 +36,9 @@ async function call_native_request(element: HTMLElement): Promise<boolean> {
 }
 
 async function call_native_exit(): Promise<void> {
-	// eslint-disable-next-line @typescript-eslint/unbound-method -- explicit .call(document) below preserves the `this` binding
-	const function_ = document.exitFullscreen ?? document.webkitExitFullscreen
+	const function_ =
+		// eslint-disable-next-line @typescript-eslint/unbound-method, @typescript-eslint/no-unnecessary-condition -- .call(document) below binds `this`; webkit fallback is absent in lib.dom types but real on older Safari
+		document.exitFullscreen ?? document.webkitExitFullscreen
 	if (typeof function_ !== 'function') return
 
 	try {

--- a/src/lib/game-kit/GameScene.svelte
+++ b/src/lib/game-kit/GameScene.svelte
@@ -98,6 +98,7 @@
 	function start_game(): void {
 		if (session.is_session_started) return
 		audio.init_audio()
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- `container` is a bind:this ref, typed non-null but undefined before mount
 		if (container && device.is_touch_primary) void fullscreen.request(container)
 		session.start_session()
 		on_start?.()

--- a/src/lib/game-kit/controls/ControlsScene.svelte
+++ b/src/lib/game-kit/controls/ControlsScene.svelte
@@ -213,6 +213,7 @@
 					svg_to_texture(TOUCH_SVG, TOUCH_TEX_W, TOUCH_TEX_H),
 				])
 
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- async race guard: the returned cleanup sets `alive = false`, which TS's flow analysis can't see across the await
 				if (!alive) {
 					kb.dispose()
 					ms.dispose()

--- a/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/KeyboardDiagram.svelte.test.ts
@@ -23,7 +23,7 @@ describe('KeyboardDiagram', () => {
 	it('does not render a visible move label text', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const texts = [...container.querySelectorAll('text')]
-		const move_label = texts.find((t) => t.textContent?.trim() === PROPS.label_move)
+		const move_label = texts.find((t) => t.textContent.trim() === PROPS.label_move)
 
 		expect(move_label).toBeUndefined()
 	})
@@ -31,7 +31,7 @@ describe('KeyboardDiagram', () => {
 	it('renders ESC text centered in its key (dominant-baseline central)', () => {
 		const { container } = render(KeyboardDiagram, { props: PROPS })
 		const texts = [...container.querySelectorAll('text')]
-		const esc = texts.find((t) => t.textContent?.trim() === 'ESC')
+		const esc = texts.find((t) => t.textContent.trim() === 'ESC')
 
 		expect(esc).toBeTruthy()
 		expect(esc?.getAttribute('dominant-baseline')).toBe('central')

--- a/src/lib/game-kit/controls/MouseDiagram.svelte.test.ts
+++ b/src/lib/game-kit/controls/MouseDiagram.svelte.test.ts
@@ -14,7 +14,7 @@ describe('MouseDiagram', () => {
 	it('does not render visible action label text', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
 		const texts = [...container.querySelectorAll('text')]
-		const action = texts.find((t) => t.textContent?.trim() === PROPS.label_action)
+		const action = texts.find((t) => t.textContent.trim() === PROPS.label_action)
 
 		expect(action).toBeUndefined()
 	})
@@ -22,7 +22,7 @@ describe('MouseDiagram', () => {
 	it('does not render visible look label text', () => {
 		const { container } = render(MouseDiagram, { props: PROPS })
 		const texts = [...container.querySelectorAll('text')]
-		const look = texts.find((t) => t.textContent?.trim() === PROPS.label_look)
+		const look = texts.find((t) => t.textContent.trim() === PROPS.label_look)
 
 		expect(look).toBeUndefined()
 	})

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte.test.ts
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte.test.ts
@@ -48,7 +48,7 @@ describe('VirtualJoystick', () => {
 
 		expect(button?.getAttribute('aria-label')).toBe(LABEL_JUMP)
 		expect(button?.querySelector('svg')).toBeTruthy()
-		expect(button?.textContent?.trim()).toBe('')
+		expect(button?.textContent.trim()).toBe('')
 	})
 
 	it('joystick-zone does not capture pointer events on non-touch devices', () => {
@@ -214,7 +214,6 @@ describe('VirtualJoystick touch handlers', () => {
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
 
 		expect(look_zone).toBeTruthy()
-		if (!look_zone) return
 
 		const t_start = make_touch(2, 300, 200, look_zone)
 
@@ -239,7 +238,6 @@ describe('VirtualJoystick touch handlers', () => {
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
 
 		expect(look_zone).toBeTruthy()
-		if (!look_zone) return
 
 		const t_start = make_touch(2, 300, 200, look_zone)
 
@@ -271,7 +269,6 @@ describe('VirtualJoystick touch handlers', () => {
 
 		expect(move_zone).toBeTruthy()
 		expect(look_zone).toBeTruthy()
-		if (!move_zone || !look_zone) return
 
 		const t1 = make_touch(1, 100, 200, move_zone)
 
@@ -366,7 +363,6 @@ describe('VirtualJoystick touch handlers', () => {
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
 
 		expect(look_zone).toBeTruthy()
-		if (!look_zone) return
 
 		const t_start = make_touch(2, 300, 200, look_zone)
 
@@ -442,7 +438,6 @@ describe('VirtualJoystick touch handlers', () => {
 		const look_zone = container.querySelectorAll('.joystick-zone').item(1)
 
 		expect(look_zone).toBeTruthy()
-		if (!look_zone) return
 
 		const t = make_touch(2, 300, 200, look_zone)
 
@@ -563,7 +558,7 @@ describe('VirtualJoystick touch handlers', () => {
 
 		expect(look_zone).toBeTruthy()
 		expect(jump_button).toBeTruthy()
-		if (!look_zone || !jump_button) return
+		if (!jump_button) return
 
 		const look_touch = make_touch(1, 300, 200, look_zone)
 

--- a/src/lib/game-kit/crt-dither.test.ts
+++ b/src/lib/game-kit/crt-dither.test.ts
@@ -167,7 +167,7 @@ describe('crt_dither.compute_scanline_factor (cosine profile)', () => {
 })
 
 describe('BAYER_MATRIX', () => {
-	it(`is a ${BAYER_SIZE}×${BAYER_SIZE} matrix`, () => {
+	it(`is a ${String(BAYER_SIZE)}×${String(BAYER_SIZE)} matrix`, () => {
 		expect(BAYER_MATRIX).toHaveLength(BAYER_SIZE)
 
 		for (const row of BAYER_MATRIX) {
@@ -175,7 +175,7 @@ describe('BAYER_MATRIX', () => {
 		}
 	})
 
-	it(`contains every integer 0..${MAX_BAYER_VALUE} exactly once (proper Bayer ordering)`, () => {
+	it(`contains every integer 0..${String(MAX_BAYER_VALUE)} exactly once (proper Bayer ordering)`, () => {
 		const seen = new Set<number>()
 
 		for (const row of BAYER_MATRIX) {
@@ -272,7 +272,7 @@ describe('crt_dither.quantize_with_dither_2d', () => {
 })
 
 describe('crt_dither.create_bayer_texture', () => {
-	it(`returns a DataTexture sized ${BAYER_SIZE}×${BAYER_SIZE} with non-zero data`, () => {
+	it(`returns a DataTexture sized ${String(BAYER_SIZE)}×${String(BAYER_SIZE)} with non-zero data`, () => {
 		const tex = crt_dither.create_bayer_texture()
 
 		expect(tex.image.width).toBe(BAYER_SIZE)
@@ -284,7 +284,7 @@ describe('crt_dither.create_bayer_texture', () => {
 		tex.dispose()
 	})
 
-	it(`stores normalized values in [0, 1) matching BAYER_MATRIX / ${SQUARED_BAYER_SIZE}`, () => {
+	it(`stores normalized values in [0, 1) matching BAYER_MATRIX / ${String(SQUARED_BAYER_SIZE)}`, () => {
 		const tex = crt_dither.create_bayer_texture()
 		const data = tex.image.data as Float32Array
 

--- a/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
+++ b/src/lib/game-kit/display/ScoreDisplay.svelte.test.ts
@@ -67,7 +67,7 @@ describe('ScoreDisplay', () => {
 	})
 
 	it('accepts custom format_score function via score_data', () => {
-		const format_score = vi.fn((v: number) => `${v} pts`)
+		const format_score = vi.fn((v: number) => `${String(v)} pts`)
 		const { container } = render(ScoreDisplay, {
 			props: {
 				score_data: make_score_data({ format_score }),

--- a/src/lib/game-kit/input/Input.svelte.test.ts
+++ b/src/lib/game-kit/input/Input.svelte.test.ts
@@ -178,7 +178,7 @@ describe('input', () => {
 		const received: Array<string> = []
 
 		canvas_element.addEventListener('pointerdown', (e: PointerEvent) =>
-			received.push(`${e.type}:${e.button}`),
+			received.push(`${e.type}:${String(e.button)}`),
 		)
 		dispatch_mouse('mousedown', { button: RIGHT_BUTTON, clientX: 200, clientY: 150 })
 		dispatch_mouse('mousedown', { button: LEFT_BUTTON })
@@ -190,7 +190,7 @@ describe('input', () => {
 		const received: Array<string> = []
 
 		canvas_element.addEventListener('pointerup', (e: PointerEvent) =>
-			received.push(`${e.type}:${e.button}`),
+			received.push(`${e.type}:${String(e.button)}`),
 		)
 		dispatch_mouse('mousedown', { button: RIGHT_BUTTON, clientX: 200, clientY: 150 })
 		dispatch_mouse('mouseup', { button: LEFT_BUTTON })
@@ -202,7 +202,7 @@ describe('input', () => {
 		const received: Array<string> = []
 
 		canvas_element.addEventListener('pointerdown', (e: PointerEvent) =>
-			received.push(`${e.type}:${e.button}`),
+			received.push(`${e.type}:${String(e.button)}`),
 		)
 		dispatch_mouse('mousedown', { button: LEFT_BUTTON })
 
@@ -213,7 +213,7 @@ describe('input', () => {
 		const received: Array<string> = []
 
 		canvas_element.addEventListener('pointerdown', (e: PointerEvent) =>
-			received.push(`${e.type}:${e.button}`),
+			received.push(`${e.type}:${String(e.button)}`),
 		)
 		dispatch_mouse('mousedown', { button: RIGHT_BUTTON, clientX: 200, clientY: 150 })
 		const start_count = received.length

--- a/src/lib/game-kit/input/Input.svelte.ts
+++ b/src/lib/game-kit/input/Input.svelte.ts
@@ -89,6 +89,7 @@ function on_mouse_down_impl(s: InputState, e: MouseEvent): void {
 	s.drag_start_x = e.clientX
 	s.drag_start_y = e.clientY
 	s.is_dragging_look = true
+	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- requestPointerLock is typed as always present but absent on older browsers
 	if (e.target instanceof HTMLElement) void e.target.requestPointerLock?.()
 }
 

--- a/src/lib/game-kit/switch/Switch.svelte
+++ b/src/lib/game-kit/switch/Switch.svelte
@@ -37,7 +37,7 @@
 		const is_h = axis === 'h'
 
 		return {
-			key: `${axis}${sx}${sy}`,
+			key: `${axis}${String(sx)}${String(sy)}`,
 			px: sx * (is_h ? g.arm_center : g.pos),
 			py: sy * (is_h ? g.pos : g.arm_center),
 			w: is_h ? g.arm : g.thickness,


### PR DESCRIPTION
## Scope

**Layer C-6** of #188. Enables `@typescript-eslint/restrict-template-expressions` (14) + `@typescript-eslint/no-unnecessary-condition` (22).

## restrict-template-expressions (String() wraps)

Wrapped non-string template-literal expressions with `String()`:
- `Logo.svelte` (`next_filter_id`)
- `Switch.svelte` (`CornerSign` values)
- `crt-dither.test.ts` (4 `it()` titles with `BAYER_SIZE` etc.)
- `ScoreDisplay.svelte.test.ts`, `Input.svelte.test.ts` ×4 (`e.button`)

## no-unnecessary-condition

### Real fix
- `Device.svelte.ts`: replaced `globalThis.matchMedia?.(...)` with `typeof globalThis.matchMedia === 'function' ? ... : null`. This gives TS the genuine `MediaQueryList | null` union (matchMedia is absent under SSR/Node, even though lib.dom types it as always present), so the downstream `mql?.` chains become necessary. Covers both "missing" and "present-but-undefined" (`vi.stubGlobal('matchMedia', undefined)`).
- Test files: removed TS-proven-redundant `if (!x) return` guards after `expect(x).toBeTruthy()` (querySelectorAll `.item()` is typed non-null) and redundant `?.` on `textContent`. The `expect().toBeTruthy()` assertion remains as the real runtime safety.

### Inline disables (defensive patterns TS flags incorrectly)
- `Fullscreen.svelte.ts` ×2: `requestFullscreen ?? webkitRequestFullscreen` — webkit fallback absent in lib.dom types but real on older Safari
- `GameScene.svelte`: `container &&` — bind:this ref typed non-null but undefined before mount
- `ControlsScene.svelte`: `if (!alive)` — async race guard; the cleanup sets `alive = false` across the await, invisible to TS flow analysis
- `Input.svelte.ts`: `requestPointerLock?.()` — typed always-present but absent on older browsers

## Caught during the work

- The `if (!look_zone || !jump_button) return` guard at VirtualJoystick.svelte.test.ts:566 mixed a redundant check (`!look_zone`) with a real one (`!jump_button`); kept `if (!jump_button) return`.
- The initial `'matchMedia' in globalThis` Device fix broke the "matchMedia unavailable" test (the property exists-but-undefined under `vi.stubGlobal`); switched to `typeof === 'function'`.

## Verification

- All gates green; tsc validates type narrowing
- 14 files changed
- Disable count: 15 → 13 (−2 rules)

**#188 stays open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)