### PR TITLE
Layer C-7: enable @typescript-eslint/no-empty-function (no-op comments in mock stubs) #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,7 +29,6 @@ const LAYER_B_DISABLES = {
 	'max-lines-per-function': 'off',
 	'@typescript-eslint/naming-convention': 'off',
 	'max-statements': 'off',
-	'@typescript-eslint/no-empty-function': 'off',
 	'sonarjs/no-duplicate-string': 'off',
 	'sonarjs/cognitive-complexity': 'off',
 	complexity: 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.96.0",
+	"version": "0.97.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/lib/game-kit/audio.ts
+++ b/src/lib/game-kit/audio.ts
@@ -7,8 +7,12 @@ function init_audio(): void {
 }
 
 function get_audio_context(): AudioContext | null {
-	// eslint-disable-next-line promise/prefer-await-to-then -- fire-and-forget; making this async would require awaiting at every audio call site
-	if (context?.state === 'suspended') void context.resume().catch(() => {})
+	if (context?.state === 'suspended') {
+		// eslint-disable-next-line promise/prefer-await-to-then -- fire-and-forget; awaiting would force every audio call site async
+		void context.resume().catch(() => {
+			/* no-op */
+		})
+	}
 
 	return context
 }

--- a/src/lib/game-kit/controls/VirtualJoystick.svelte
+++ b/src/lib/game-kit/controls/VirtualJoystick.svelte
@@ -197,7 +197,11 @@
 	}
 
 	onMount(() => {
-		if (!('ontouchstart' in globalThis)) return () => {}
+		if (!('ontouchstart' in globalThis)) {
+			return () => {
+				/* no-op */
+			}
+		}
 
 		move_zone.addEventListener('touchstart', on_move_start, { passive: false })
 		look_zone.addEventListener('touchstart', on_look_start, { passive: false })

--- a/src/lib/game-kit/device.test.ts
+++ b/src/lib/game-kit/device.test.ts
@@ -13,7 +13,9 @@ function make_mock_mql(initial: boolean): MediaQueryList & { _fire: (v: boolean)
 		addEventListener(_: string, function_: EventListenerOrEventListenerObject): void {
 			listeners.push(function_ as unknown as ChangeListener)
 		},
-		removeEventListener(): void {},
+		removeEventListener(): void {
+			/* no-op */
+		},
 		_fire(v: boolean): void {
 			for (const function_ of listeners) function_({ matches: v })
 		},

--- a/src/lib/game-kit/input/Input.svelte.test.ts
+++ b/src/lib/game-kit/input/Input.svelte.test.ts
@@ -235,7 +235,9 @@ describe('input', () => {
 
 	it('right mouse up exits pointer lock when locked', () => {
 		vi.spyOn(Document.prototype, 'pointerLockElement', 'get').mockReturnValue(document.body)
-		const spy = vi.spyOn(Document.prototype, 'exitPointerLock').mockImplementation(() => {})
+		const spy = vi.spyOn(Document.prototype, 'exitPointerLock').mockImplementation(() => {
+			/* no-op */
+		})
 
 		dispatch_mouse('mouseup', { button: RIGHT_BUTTON })
 		expect(spy).toHaveBeenCalledTimes(1)
@@ -243,7 +245,9 @@ describe('input', () => {
 
 	it('right mouse up does not call exitPointerLock when not locked', () => {
 		vi.spyOn(Document.prototype, 'pointerLockElement', 'get').mockReturnValue(null)
-		const spy = vi.spyOn(Document.prototype, 'exitPointerLock').mockImplementation(() => {})
+		const spy = vi.spyOn(Document.prototype, 'exitPointerLock').mockImplementation(() => {
+			/* no-op */
+		})
 
 		dispatch_mouse('mouseup', { button: RIGHT_BUTTON })
 		expect(spy).not.toHaveBeenCalled()

--- a/src/lib/game-kit/player/Player.svelte.test.ts
+++ b/src/lib/game-kit/player/Player.svelte.test.ts
@@ -16,9 +16,15 @@ const { tick_holder, mock_input } = vi.hoisted(() => ({
 		pitch: 0,
 		is_jump_requested: false,
 		is_sprinting: false,
-		clear_jump_request: () => {},
-		apply_look_delta: () => {},
-		set_joystick_look: () => {},
+		clear_jump_request: () => {
+			/* no-op */
+		},
+		apply_look_delta: () => {
+			/* no-op */
+		},
+		set_joystick_look: () => {
+			/* no-op */
+		},
 	},
 }))
 

--- a/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
+++ b/src/lib/game-kit/scene/FloorCredits.svelte.test.ts
@@ -4,7 +4,11 @@ import FloorCredits from './FloorCredits.svelte'
 import FLOOR_CREDITS_SOURCE from './FloorCredits.svelte?raw'
 
 vi.mock('@threlte/core', () => ({ T: {}, useTask: vi.fn() }))
-vi.mock('@threlte/extras', () => ({ Text: function Text() {} }))
+vi.mock('@threlte/extras', () => ({
+	Text: function Text() {
+		/* no-op */
+	},
+}))
 
 const SAMPLE_CREDITS = 'CREDITS\n\nSponsor A\n\nSponsor B'
 const START_Z = 10

--- a/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
+++ b/src/lib/game-kit/scene/SceneObjects.svelte.test.ts
@@ -12,15 +12,35 @@ vi.mock('@threlte/core', () => ({
 }))
 vi.mock('@threlte/extras', () => ({
 	interactivity: vi.fn(),
-	Text: function Text() {},
+	Text: function Text() {
+		/* no-op */
+	},
 }))
-vi.mock('./Room.svelte', () => ({ default: function Room() {} }))
-vi.mock('$lib/game-kit/player/Player.svelte', () => ({ default: function Player() {} }))
+vi.mock('./Room.svelte', () => ({
+	default: function Room() {
+		/* no-op */
+	},
+}))
+vi.mock('$lib/game-kit/player/Player.svelte', () => ({
+	default: function Player() {
+		/* no-op */
+	},
+}))
 vi.mock('$lib/game-kit/display/ScoreDisplay.svelte', () => ({
-	default: function ScoreDisplay() {},
+	default: function ScoreDisplay() {
+		/* no-op */
+	},
 }))
-vi.mock('$lib/game-kit/switch/Switch.svelte', () => ({ default: function Switch() {} }))
-vi.mock('./FloorCredits.svelte', () => ({ default: function FloorCredits() {} }))
+vi.mock('$lib/game-kit/switch/Switch.svelte', () => ({
+	default: function Switch() {
+		/* no-op */
+	},
+}))
+vi.mock('./FloorCredits.svelte', () => ({
+	default: function FloorCredits() {
+		/* no-op */
+	},
+}))
 vi.mock('$lib/game-kit/Fullscreen.svelte', () => ({ fullscreen: { is_active: false } }))
 vi.mock('$lib/game-kit/State.svelte', () => ({ game_state: { is_alt: false } }))
 vi.mock('$lib/game-kit/input/pointer-compute.js', () => ({
@@ -64,7 +84,11 @@ vi.mock('$lib/game-kit/Crt.svelte', () => ({
 vi.mock('$lib/game-kit/display/Fps.svelte', () => ({
 	fps: { is_fps_enabled: true, current_fps_text: '---', toggle: vi.fn() },
 }))
-vi.mock('$lib/game-kit/display/FpsDisplay.svelte', () => ({ default: function FpsDisplay() {} }))
+vi.mock('$lib/game-kit/display/FpsDisplay.svelte', () => ({
+	default: function FpsDisplay() {
+		/* no-op */
+	},
+}))
 
 const MOCK_CREDITS_START_Z = 10
 const MOCK_CREDITS_END_Z = -10

--- a/src/lib/game-kit/switch/FullscreenSwitchInput.svelte.test.ts
+++ b/src/lib/game-kit/switch/FullscreenSwitchInput.svelte.test.ts
@@ -16,7 +16,9 @@ describe('fullscreen_switch_input', () => {
 		container = document.createElement('div')
 		document.body.append(container)
 		fullscreen_switch_input.set_container(container)
-		vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 	})
 
 	afterEach(() => {
@@ -63,7 +65,9 @@ describe('fullscreen_switch_input', () => {
 
 	it('plays switch click sound when session is started and container is set', () => {
 		session.start_session()
-		const sound_spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const sound_spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		vi.spyOn(fullscreen, 'request').mockResolvedValue()
 		fullscreen_switch_input.on_click()
@@ -71,7 +75,9 @@ describe('fullscreen_switch_input', () => {
 	})
 
 	it('does not play sound when session is not started', () => {
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		fullscreen_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()
@@ -80,7 +86,9 @@ describe('fullscreen_switch_input', () => {
 	it('does not play sound when container is not set', () => {
 		fullscreen_switch_input.set_container(null)
 		session.start_session()
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		fullscreen_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()

--- a/src/lib/game-kit/switch/Switch.svelte.test.ts
+++ b/src/lib/game-kit/switch/Switch.svelte.test.ts
@@ -6,7 +6,11 @@ import Switch from './Switch.svelte'
 import SWITCH_SOURCE from './Switch.svelte?raw'
 
 vi.mock('@threlte/core', () => ({ T: {} }))
-vi.mock('@threlte/extras', () => ({ Text: function Text() {} }))
+vi.mock('@threlte/extras', () => ({
+	Text: function Text() {
+		/* no-op */
+	},
+}))
 vi.mock('$lib/game-kit/fonts', () => ({
 	fonts: { get_font: vi.fn(() => ''), get_font_size_multiplier: vi.fn(() => 1) },
 }))

--- a/src/lib/game-kit/switch/alt-switch-input.test.ts
+++ b/src/lib/game-kit/switch/alt-switch-input.test.ts
@@ -34,14 +34,18 @@ describe('alt_switch_input', () => {
 
 	it('plays switch click sound when session is started', () => {
 		session.start_session()
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		alt_switch_input.on_click()
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not play switch click sound when session is not started', () => {
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		alt_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()

--- a/src/lib/game-kit/switch/crt-switch-input.test.ts
+++ b/src/lib/game-kit/switch/crt-switch-input.test.ts
@@ -34,14 +34,18 @@ describe('crt_switch_input', () => {
 
 	it('plays switch click sound when session is started', () => {
 		session.start_session()
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		crt_switch_input.on_click()
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not play switch click sound when session is not started', () => {
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		crt_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()

--- a/src/lib/game-kit/switch/fps-switch-input.test.ts
+++ b/src/lib/game-kit/switch/fps-switch-input.test.ts
@@ -34,14 +34,18 @@ describe('fps_switch_input', () => {
 
 	it('plays switch click sound when session is started', () => {
 		session.start_session()
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		fps_switch_input.on_click()
 		expect(spy).toHaveBeenCalledTimes(1)
 	})
 
 	it('does not play switch click sound when session is not started', () => {
-		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		const spy = vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 
 		fps_switch_input.on_click()
 		expect(spy).not.toHaveBeenCalled()

--- a/src/lib/game-kit/switch/switch-input.test.ts
+++ b/src/lib/game-kit/switch/switch-input.test.ts
@@ -10,7 +10,9 @@ describe('create_switch_input', () => {
 	beforeEach(() => {
 		session.reset_session()
 		action = vi.fn<() => void>()
-		vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {})
+		vi.spyOn(switch_audio, 'play_switch_click').mockImplementation(() => {
+			/* no-op */
+		})
 	})
 
 	afterEach(() => {

--- a/src/lib/game/Audio.svelte.test.ts
+++ b/src/lib/game/Audio.svelte.test.ts
@@ -73,7 +73,9 @@ describe('game audio envelope', () => {
 	it('normal mode uses flat envelope — no exponential ramp', () => {
 		const { ctx, gain_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.play_tone('green', 200, false)
@@ -85,7 +87,9 @@ describe('game audio envelope', () => {
 	it('cyber mode applies exponential gain ramp', () => {
 		const { ctx, gain_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.play_tone('green', 200, true)
@@ -96,7 +100,9 @@ describe('game audio envelope', () => {
 	it('play_error_tone uses ERROR_FREQ', () => {
 		const { ctx, osc_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.play_error_tone(3000, false)
@@ -107,7 +113,9 @@ describe('game audio envelope', () => {
 	it('start_tone starts oscillator without calling stop', () => {
 		const { ctx, osc_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.start_tone('green', false)
@@ -119,7 +127,9 @@ describe('game audio envelope', () => {
 	it('stop_tone calls stop on the active oscillator', () => {
 		const { ctx, osc_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.start_tone('red', false)
@@ -131,7 +141,9 @@ describe('game audio envelope', () => {
 	it('play_error_tone normal mode uses flat envelope', () => {
 		const { ctx, gain_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.play_error_tone(3000, false)
@@ -143,7 +155,9 @@ describe('game audio envelope', () => {
 	it('play_error_tone cyber mode applies exponential gain ramp', () => {
 		const { ctx, gain_node } = make_mock_context()
 
-		vi.spyOn(audio, 'init_audio').mockImplementation(() => {})
+		vi.spyOn(audio, 'init_audio').mockImplementation(() => {
+			/* no-op */
+		})
 		vi.spyOn(audio, 'get_audio_context').mockReturnValue(ctx as unknown as AudioContext)
 
 		game_audio.play_error_tone(3000, true)

--- a/src/lib/game/Board.svelte.test.ts
+++ b/src/lib/game/Board.svelte.test.ts
@@ -7,7 +7,11 @@ import BOARD_SOURCE from './Board.svelte?raw'
 import type { GameBoardData } from './types'
 
 vi.mock('@threlte/core', () => ({ T: {}, useTask: vi.fn() }))
-vi.mock('@threlte/extras', () => ({ Text: function Text() {} }))
+vi.mock('@threlte/extras', () => ({
+	Text: function Text() {
+		/* no-op */
+	},
+}))
 
 function make_game_data(overrides: Partial<GameBoardData> = {}): GameBoardData {
 	return {

--- a/src/lib/game/Scene.svelte.test.ts
+++ b/src/lib/game/Scene.svelte.test.ts
@@ -5,8 +5,16 @@ import { describe, expect, it, vi } from 'vitest'
 import { render } from 'vitest-browser-svelte'
 import Scene from './Scene.svelte'
 
-vi.mock('$lib/game-kit/scene/SceneObjects.svelte', () => ({ default: function SceneObjects() {} }))
-vi.mock('$lib/game/Board.svelte', () => ({ default: function Board() {} }))
+vi.mock('$lib/game-kit/scene/SceneObjects.svelte', () => ({
+	default: function SceneObjects() {
+		/* no-op */
+	},
+}))
+vi.mock('$lib/game/Board.svelte', () => ({
+	default: function Board() {
+		/* no-op */
+	},
+}))
 vi.mock('$lib/game/board-config', () => ({
 	SCORE_DISPLAY_Z: -4.65,
 }))

--- a/src/lib/game/Score.svelte.test.ts
+++ b/src/lib/game/Score.svelte.test.ts
@@ -231,7 +231,12 @@ describe('load_stored_data', () => {
 	})
 
 	it('returns {score: 0, round: 0} when nothing is stored', () => {
-		vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {} })
+		vi.stubGlobal('localStorage', {
+			getItem: () => null,
+			setItem: () => {
+				/* no-op */
+			},
+		})
 		expect(load_stored_data(DEFAULT_KEYS)).toEqual({ score: 0, round: 0 })
 	})
 
@@ -248,7 +253,9 @@ describe('load_stored_data', () => {
 
 				return null
 			},
-			setItem: () => {},
+			setItem: () => {
+				/* no-op */
+			},
 		})
 		expect(load_stored_data(DEFAULT_KEYS)).toEqual({ score: stored_score, round: stored_round })
 	})
@@ -262,7 +269,9 @@ describe('load_stored_data', () => {
 
 				return null
 			},
-			setItem: () => {},
+			setItem: () => {
+				/* no-op */
+			},
 		})
 		expect(load_stored_data(DEFAULT_KEYS)).toEqual({ score: 0, round: 0 })
 	})
@@ -290,7 +299,9 @@ describe('load_stored_data', () => {
 
 				return null
 			},
-			setItem: () => {},
+			setItem: () => {
+				/* no-op */
+			},
 		})
 		expect(load_stored_data(custom_keys)).toEqual({ score: stored_score, round: stored_round })
 	})
@@ -309,7 +320,12 @@ describe('create_score isolation', () => {
 	it('custom key prefix stores to different keys than default', () => {
 		const custom = create_score('test')
 
-		vi.stubGlobal('localStorage', { getItem: () => null, setItem: () => {} })
+		vi.stubGlobal('localStorage', {
+			getItem: () => null,
+			setItem: () => {
+				/* no-op */
+			},
+		})
 		expect(custom.high_score).toBe(0)
 		vi.unstubAllGlobals()
 	})

--- a/src/lib/game/board-input.ts
+++ b/src/lib/game/board-input.ts
@@ -9,9 +9,15 @@ interface BoardCallbacks {
 }
 
 let board_callbacks: BoardCallbacks = {
-	on_press: () => {},
-	on_release: () => {},
-	on_start: () => {},
+	on_press: () => {
+		/* no-op */
+	},
+	on_release: () => {
+		/* no-op */
+	},
+	on_start: () => {
+		/* no-op */
+	},
 }
 
 function configure(cbs: BoardCallbacks): void {

--- a/src/lib/game/flash.test.ts
+++ b/src/lib/game/flash.test.ts
@@ -88,7 +88,9 @@ describe('cancel_flash', () => {
 describe('run_victory_flash', () => {
 	beforeEach(() => {
 		vi.useFakeTimers()
-		vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {})
+		vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {
+			/* no-op */
+		})
 	})
 
 	afterEach(() => {
@@ -116,7 +118,9 @@ describe('run_victory_flash', () => {
 	})
 
 	it('calls play_tone for each color during burst', async () => {
-		const spy = vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {})
+		const spy = vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {
+			/* no-op */
+		})
 		const s = make_state()
 		const t = make_timers()
 
@@ -157,7 +161,9 @@ describe('run_victory_flash', () => {
 
 	it('works with a custom color subset', async () => {
 		const custom: Array<ButtonColor> = ['green', 'blue']
-		const spy = vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {})
+		const spy = vi.spyOn(game_audio, 'play_tone').mockImplementation(() => {
+			/* no-op */
+		})
 		const s = make_state()
 		const t = make_timers()
 

--- a/src/routes/e2e-helpers.ts
+++ b/src/routes/e2e-helpers.ts
@@ -14,10 +14,18 @@ export async function stub_touch_primary(page: Page, is_touch: boolean): Promise
 						matches,
 						media: input,
 						onchange: null,
-						addEventListener() {},
-						removeEventListener() {},
-						addListener() {},
-						removeListener() {},
+						addEventListener() {
+							/* no-op */
+						},
+						removeEventListener() {
+							/* no-op */
+						},
+						addListener() {
+							/* no-op */
+						},
+						removeListener() {
+							/* no-op */
+						},
 						dispatchEvent() {
 							return false
 						},


### PR DESCRIPTION
## Scope

**Layer C-7** of #188. Enables `@typescript-eslint/no-empty-function` (53 violations).

## Approach

All 53 are intentional empty bodies — mock-object no-op methods (`addEventListener() {}`, `removeEventListener() {}`), stub callbacks, and fire-and-forget `.catch(() => {})`. The rule treats a body containing a comment as non-empty, so each was filled with `/* no-op */` (a position-based script using ESLint's location data, then prettier-formatted).

Distribution: ~48 in test files (mock stubs), 5 in source (`audio.ts` fire-and-forget catch, `VirtualJoystick.svelte` onMount early-return cleanup, `board-input.ts` default handlers).

## Follow-on fixes

Inserting the multi-line `/* no-op */` body turned two single-statement `if` bodies multi-line, tripping `curly`:
- `audio.ts`: wrapped the `if (context?.state === 'suspended')` body in braces; moved the `promise/prefer-await-to-then` disable to the `.catch` line
- `VirtualJoystick.svelte`: wrapped the `onMount` early-return in braces

## Verification

- All gates green: lint, tsc, cspell, 1065 unit tests
- 21 files changed
- Disable count: 13 → 12 (−1 rule)

**#188 stays open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)