### PR TITLE
Layer C-10: mark unicorn/no-null as a permanent disable (DOM/Three.js null alignment) #188

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,10 +19,16 @@ const LAYER_B_DISABLES = {
 	// the rule treats the snippet call as a value-consuming expression, but `@render`
 	// is a template directive. Per-line disables on every snippet site is noisier.
 	'sonarjs/no-use-of-empty-return-value': 'off',
+	// `unicorn/no-null` prefers `undefined`, but this codebase deliberately uses `null`
+	// to mirror the DOM / Three.js / Web APIs it wraps (Element | null, AudioContext |
+	// null, CanvasTexture | null, Three.js texture uniforms `{ value: null }`, Response
+	// body, document.fullscreenElement / pointerLockElement). Forcing `undefined` would
+	// add boundary-conversion noise plus ~15 external-API inline disables for a pure
+	// style change. Always disabled.
+	'unicorn/no-null': 'off',
 
 	// === Layer C follow-up (high-volume manual refactor) ===
 	'id-length': 'off',
-	'unicorn/no-null': 'off',
 	'import/exports-last': 'off',
 	'no-restricted-syntax': 'off',
 	'max-lines-per-function': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.100.0",
+	"version": "0.101.0",
 	"keywords": [
 		"svelte"
 	],


### PR DESCRIPTION
partially addresses #188