### PR TITLE
Reduce eslint customization: adopt kit 0.196.0 fixes, drop 3 disables + prevent-abbr override #220

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,20 +5,15 @@ import svelteConfig from './svelte.config.js'
 // patterns in a way that cannot be resolved by code changes alone. All Layer C follow-up
 // PRs (#191-#217) have been shipped; these are the entries that survived the migration.
 // See issue #188 for the full migration history.
+//
+// Note: `prefer-arrow-callback`, `unicorn/no-useless-undefined`,
+// `sonarjs/no-use-of-empty-return-value`, and the project-wide
+// `unicorn/prevent-abbreviations` allowList previously lived here but were moved
+// into kit (issues #432-435, kit 0.196.0) and removed from this file.
 const PERMANENT_DISABLES = {
-	// `prefer-arrow-callback` rewrites `function () {}` → `() => {}` which breaks
-	// `new`-constructibility (Audio mock regression). Always disabled.
-	'prefer-arrow-callback': 'off',
-	// `unicorn/no-useless-undefined` strips required-by-signature undefined args
-	// (broke vi.stubGlobal / mockResolvedValue calls). Always disabled.
-	'unicorn/no-useless-undefined': 'off',
 	// `dot-notation` converts bracket access to dot access, but TS index-signature
 	// types REQUIRE bracket access. Always disabled.
 	'dot-notation': 'off',
-	// `sonarjs/no-use-of-empty-return-value` fires on Svelte `{@render snippet()}` —
-	// the rule treats the snippet call as a value-consuming expression, but `@render`
-	// is a template directive. Per-line disables on every snippet site is noisier.
-	'sonarjs/no-use-of-empty-return-value': 'off',
 	// `unicorn/no-null` prefers `undefined`, but this codebase deliberately uses `null`
 	// to mirror the DOM / Three.js / Web APIs it wraps (Element | null, AudioContext |
 	// null, CanvasTexture | null, Three.js texture uniforms `{ value: null }`, Response
@@ -58,37 +53,8 @@ const PERMANENT_DISABLES = {
 // Tracked as Layer C follow-up (add a scripts tsconfig; restructure templates).
 const FILE_IGNORES = ['scripts/**', 'templates/**']
 
-// Kit 0.189 ships `unicorn/prevent-abbreviations` allowList inside SVELTE_FILE_PATTERNS.svelte,
-// but plain `.ts` files (non-Svelte) don't inherit it. Re-apply the same allowList project-wide
-// so idiomatic short names (e, el, ctx, btn, idx, etc.) don't fire in CLI helpers, hash utilities,
-// or e2e tests. Also adds `e2e` so Playwright filename convention (page.e2e.ts) doesn't get
-// expanded to absurd `page.error2error.ts`.
-const PREVENT_ABBREVIATIONS_OVERRIDE = {
-	'unicorn/prevent-abbreviations': [
-		'error',
-		{
-			allowList: {
-				Props: true,
-				e: true,
-				e2e: true,
-				el: true,
-				ctx: true,
-				btn: true,
-				idx: true,
-				opts: true,
-				params: true,
-				args: true,
-			},
-		},
-	],
-}
-
 export default create_sveltekit_config({
 	gitignore_path: new URL('./.gitignore', import.meta.url),
 	tsconfig_root_dir: import.meta.dirname,
 	svelte_config: svelteConfig,
-}).concat(
-	{ ignores: FILE_IGNORES },
-	{ rules: PERMANENT_DISABLES },
-	{ rules: PREVENT_ABBREVIATIONS_OVERRIDE },
-)
+}).concat({ ignores: FILE_IGNORES }, { rules: PERMANENT_DISABLES })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.107.0",
+	"version": "0.108.0",
 	"keywords": [
 		"svelte"
 	],
@@ -44,7 +44,7 @@
 		"@eslint/compat": "^2.1.0",
 		"@eslint/js": "^10.0.1",
 		"@ianvs/prettier-plugin-sort-imports": "^4.7.1",
-		"@joshuafolkken/kit": "0.192.0",
+		"@joshuafolkken/kit": "0.196.0",
 		"@playwright/test": "1.60.0",
 		"@size-limit/file": "^12.1.0",
 		"@sveltejs/adapter-cloudflare": "^7.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,8 @@ importers:
         specifier: ^4.7.1
         version: 4.7.1(prettier@3.8.3)
       '@joshuafolkken/kit':
-        specifier: 0.192.0
-        version: 0.192.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
+        specifier: 0.196.0
+        version: 0.196.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -1722,8 +1722,8 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
-  '@joshuafolkken/kit@0.192.0':
-    resolution: {integrity: sha512-zMFExUdAyJa2td5rP6mYGGHNzv42Qb52Q7tCfnjHK+TVuO3jgrNa+DvICTnbq2LIz/oXlpet4Mn+B8XSsaj5XQ==, tarball: https://npm.pkg.github.com/download/@joshuafolkken/kit/0.192.0/d772c6c05e6474728cd0e890a3a51bca00fcd89e}
+  '@joshuafolkken/kit@0.196.0':
+    resolution: {integrity: sha512-YjLfUdy2PzWaYmscy9c+kBgChE+pHdGo2D8AHpseyHNTcfjujsP9MiqtApEVkj1hYpoDKayY34ynw/z6uNqzWA==, tarball: https://npm.pkg.github.com/download/@joshuafolkken/kit/0.196.0/14c5f82550140875894c39e8e3453dd0a27af55e}
     engines: {node: '>=22.19.0'}
     hasBin: true
     peerDependencies:
@@ -6020,7 +6020,7 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@joshuafolkken/kit@0.192.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(typescript@6.0.3)':
+  '@joshuafolkken/kit@0.196.0(@playwright/test@1.60.0)(@typescript-eslint/utils@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(svelte@5.55.9(@typescript-eslint/types@8.60.0))(typescript@6.0.3)':
     dependencies:
       '@eslint/compat': 2.1.0(eslint@10.4.0(jiti@2.7.0))
       '@eslint/js': 10.0.1(eslint@10.4.0(jiti@2.7.0))

--- a/src/lib/game-kit/switch/Switch.svelte
+++ b/src/lib/game-kit/switch/Switch.svelte
@@ -95,11 +95,12 @@
 		arm_center: geom.corner_pos - geom.corner_arm / HALF_DIVISOR,
 	})
 	const corner_bars = $derived(
-		CORNER_SIGNS.flatMap(function (sx) {
-			return CORNER_SIGNS.flatMap(function (sy) {
-				return [make_bar(sx, sy, 'h', corner_geom), make_bar(sx, sy, 'v', corner_geom)]
-			})
-		}),
+		CORNER_SIGNS.flatMap((sx) =>
+			CORNER_SIGNS.flatMap((sy) => [
+				make_bar(sx, sy, 'h', corner_geom),
+				make_bar(sx, sy, 'v', corner_geom),
+			]),
+		),
 	)
 	const hit_area_w = $derived(geom.panel_size + HIT_AREA_PADDING)
 	const hit_area_h = $derived(geom.panel_size + HIT_AREA_PADDING)

--- a/src/lib/game-kit/switch/switch-audio.test.ts
+++ b/src/lib/game-kit/switch/switch-audio.test.ts
@@ -14,7 +14,7 @@ describe('switch_audio.play_switch_click', () => {
 		vi.resetModules()
 		play_mock = vi.fn().mockResolvedValue(undefined)
 		shared_instance = { currentTime: 0, play: play_mock }
-		audio_ctor = vi.fn().mockImplementation(function () {
+		audio_ctor = vi.fn().mockImplementation(function audio_constructor() {
 			return shared_instance
 		})
 		vi.stubGlobal('Audio', audio_ctor)


### PR DESCRIPTION
closes #220

Phase 1 of eslint customization reduction. Adopts kit 0.196.0 (issues #432-435) and removes the now-redundant local config.

- Bump kit 0.195 → 0.196
- Remove from PERMANENT_DISABLES: `prefer-arrow-callback`, `unicorn/no-useless-undefined`, `sonarjs/no-use-of-empty-return-value` (kit now covers all 3, 0 residual)
- Remove `PREVENT_ABBREVIATIONS_OVERRIDE` block (kit applies allowList project-wide + `e2e`)
- Source: `Switch.svelte` flatMap → arrow (×2); `switch-audio.test.ts` mock → named function expression
- Result: 11 → 8 local disables