### PR TITLE
Tripwire-guard divergent scaffold templates and fix the Board #137 readability drift #267

### DIFF
--- a/.template-source-manifest.json
+++ b/.template-source-manifest.json
@@ -1,3 +1,18 @@
 {
-	"vite.config.ts": "bc68bb4f7ab611fedd87c8f3fe7436e1598974c5135ff34c546e237521955463"
+	"vite.config.ts": "bc68bb4f7ab611fedd87c8f3fe7436e1598974c5135ff34c546e237521955463",
+	"src/app.html": "be1f5575e2daf9cff8eee03da181bfd4488342acdfe0c686cce28c35f8668996",
+	"src/hooks.server.ts": "ff893c4f9f61353fd7c6b6ec15fc63ef1066d30e4d61d960695edd4b099c4d27",
+	"src/lib/game/messages.ts": "e9cf0c8e7a140744e0276bb64ca97d1b8245ba64d99043c0e96de4693fd6bb32",
+	"src/routes/+layout.svelte": "469ce60fbdc09c47cd560dfcffeca340672a5bc19313f605633b05cd5c12a704",
+	"src/routes/+page.svelte": "2cd2b749259686729a20528c8d784a13215cdf88b9c7b04174c0ca535f64e700",
+	"src/routes/+page.ts": "2b17e9e785d0d48d8947f38c1047a817a6d81d31b06bdf5ac587e2050c1ca110",
+	"src/lib/game/Board.svelte": "925511e6cee24719e58644f7d2a765b3e9be4d6fd7bde17f50864df4dcfbb7b8",
+	"src/lib/game/Scene.svelte": "0d2d86475d762689c18823c55a27b653585c4eae270e5cb80357fd186579f219",
+	"src/lib/game/Game.svelte.ts": "f994a561f8e15b46fdc04a0c3513a0e90ab26e9140947a82b2b1454801436d51",
+	"src/lib/game/types.ts": "61b3a3c854e2a9259649ddbce46fb5792e91b4a9d2b5ab867e7ce5cbe2e8b29c",
+	"src/lib/game/board-config.ts": "dd03a83990cde59324c5ea17c45184cfef9620987f48a636904115a9aa5a5b5a",
+	"src/lib/game/board-input.ts": "738f3c6f512e27a06e47a04cf376654402deed1bb188dbbccaf8c1fd94c5802a",
+	"src/lib/game/audio.ts": "bbc1e149e27861a44e8f4355fcfa58d0b113d313361114f00e4b25ccc600a0a5",
+	"src/lib/game/credits.ts": "6ab13a4a5e40ddac1221a701d98ba13af21d74feb2d306f18cd2dc1be4277648",
+	"src/lib/game/flash.ts": "001523e112281419f5d2820e2747d8b1518c51506fc3eab569f60d7f293b2470"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.127.0",
+	"version": "0.128.0",
 	"keywords": [
 		"svelte"
 	],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,16 +235,16 @@ importers:
         version: 12.1.0(size-limit@12.1.0(jiti@2.7.0))
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.8
-        version: 7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260530.1))
+        version: 7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260530.1))
       '@sveltejs/kit':
         specifier: ^2.61.1
-        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@sveltejs/package':
         specifier: ^2.5.7
         version: 2.5.7(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.1.2
-        version: 7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.3.0)
@@ -253,7 +253,7 @@ importers:
         version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@threlte/core':
         specifier: ^8.5.16
         version: 8.5.16(svelte@5.56.0(@typescript-eslint/types@8.60.0))(three@0.184.0)
@@ -268,10 +268,10 @@ importers:
         version: 0.184.1
       '@vite-pwa/sveltekit':
         specifier: ^1.1.0
-        version: 1.1.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 1.1.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       '@vitest/browser-playwright':
         specifier: ^4.1.7
-        version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+        version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)
       cookie:
         specifier: ^0.7.0
         version: 0.7.2
@@ -334,13 +334,13 @@ importers:
         version: 8.60.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       vite:
         specifier: ^8.0.14
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest-browser-svelte:
         specifier: ^2.1.1
         version: 2.1.1(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vitest@4.1.7)
@@ -6292,18 +6292,18 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260530.1))':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(wrangler@4.95.0(@cloudflare/workers-types@4.20260530.1))':
     dependencies:
       '@cloudflare/workers-types': 4.20260530.1
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       worktop: 0.8.0-next.18
       wrangler: 4.95.0(@cloudflare/workers-types@4.20260530.1)
 
-  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.7.2
@@ -6315,7 +6315,7 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -6330,14 +6330,14 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
   '@tailwindcss/forms@0.5.11(tailwindcss@4.3.0)':
     dependencies:
@@ -6410,12 +6410,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@testing-library/svelte-core@1.0.0(svelte@5.56.0(@typescript-eslint/types@8.60.0))':
     dependencies:
@@ -6663,41 +6663,41 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vite-pwa/sveltekit@1.1.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)':
+  '@vite-pwa/sveltekit@1.1.0(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)':
     dependencies:
-      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@sveltejs/kit': 2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.0(@typescript-eslint/types@8.60.0))(typescript@6.0.3)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       kolorist: 1.8.0
       tinyglobby: 0.2.16
-      vite-plugin-pwa: 1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+      vite-plugin-pwa: 1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
     transitivePeerDependencies:
       - supports-color
       - vite
       - workbox-build
       - workbox-window
 
-  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)':
+  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -6714,13 +6714,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -8792,18 +8792,18 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       workbox-build: 7.4.1
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8816,22 +8816,23 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   vitest-browser-svelte@2.1.1(svelte@5.56.0(@typescript-eslint/types@8.60.0))(vitest@4.1.7):
     dependencies:
       '@testing-library/svelte-core': 1.0.0(svelte@5.56.0(@typescript-eslint/types@8.60.0))
       svelte: 5.56.0(@typescript-eslint/types@8.60.0)
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -8848,11 +8849,11 @@ snapshots:
       tinyexec: 1.2.3
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
 

--- a/scripts/template-source-logic.ts
+++ b/scripts/template-source-logic.ts
@@ -35,13 +35,36 @@ const COPY_PAIRS: ReadonlyArray<TemplateSourcePair> = [
 	{ template: 'templates/src/lib/game/Score.svelte.ts', source: 'src/lib/game/Score.svelte.ts' },
 ]
 
-// Tripwire pairs: the template intentionally diverges from the root source
-// (e.g. templates/vite.config.ts omits the in-repo Vitest config). A source
-// edit trips the guard and forces a conscious re-check; propagation stays a
-// human decision recorded by `reconcile`. Adding a pair to either list needs
-// no other wiring — the lefthook pre-commit guard runs `--check` unconditionally.
+// Tripwire pairs: the template is a hand-maintained port of the root source and
+// CANNOT be generated mechanically — the scaffold imports the published
+// `@joshuafolkken/game-kit` package, whose curated namespace API (e.g.
+// `credits_scroll.make_credits_scroll_bounds`) differs in symbol shape from the
+// bare internal modules the in-repo demo uses (`make_credits_scroll_bounds` from
+// `$lib/game-kit/scene/credits-config`). So a root edit cannot auto-propagate;
+// it trips the guard and forces a conscious re-check + manual port. The recorded
+// hash is the source's last-reviewed state. Adding a pair needs no other wiring —
+// the lefthook pre-commit guard runs `--check` unconditionally.
+//
+// `source` is the in-repo demo file; `template` is its scaffold counterpart. The
+// messages pair crosses directories: the demo keeps messages under
+// src/lib/game/, the scaffold at src/lib/.
 const TRIPWIRE_PAIRS: ReadonlyArray<TemplateSourcePair> = [
 	{ template: 'templates/vite.config.ts', source: 'vite.config.ts' },
+	{ template: 'templates/src/app.html', source: 'src/app.html' },
+	{ template: 'templates/src/hooks.server.ts', source: 'src/hooks.server.ts' },
+	{ template: 'templates/src/lib/messages.ts', source: 'src/lib/game/messages.ts' },
+	{ template: 'templates/src/routes/+layout.svelte', source: 'src/routes/+layout.svelte' },
+	{ template: 'templates/src/routes/+page.svelte', source: 'src/routes/+page.svelte' },
+	{ template: 'templates/src/routes/+page.ts', source: 'src/routes/+page.ts' },
+	{ template: 'templates/src/lib/game/Board.svelte', source: 'src/lib/game/Board.svelte' },
+	{ template: 'templates/src/lib/game/Scene.svelte', source: 'src/lib/game/Scene.svelte' },
+	{ template: 'templates/src/lib/game/Game.svelte.ts', source: 'src/lib/game/Game.svelte.ts' },
+	{ template: 'templates/src/lib/game/types.ts', source: 'src/lib/game/types.ts' },
+	{ template: 'templates/src/lib/game/board-config.ts', source: 'src/lib/game/board-config.ts' },
+	{ template: 'templates/src/lib/game/board-input.ts', source: 'src/lib/game/board-input.ts' },
+	{ template: 'templates/src/lib/game/audio.ts', source: 'src/lib/game/audio.ts' },
+	{ template: 'templates/src/lib/game/credits.ts', source: 'src/lib/game/credits.ts' },
+	{ template: 'templates/src/lib/game/flash.ts', source: 'src/lib/game/flash.ts' },
 ]
 
 // Internal maintainer guard state, kept at the repo root (not under templates/)

--- a/scripts/templates-content.test.ts
+++ b/scripts/templates-content.test.ts
@@ -22,6 +22,42 @@ describe('templates/ excludes root-single-sourced files (regression for #266)', 
 	})
 })
 
+describe('templates/src/lib/game/Board.svelte has the #137 readability behavior (regression for #267 drift)', () => {
+	const board_source = readFileSync(path.join(TEMPLATES_GAME_DIR, 'Board.svelte'), 'utf8')
+
+	it('wraps the multi-line GAME OVER label instead of showing it on one line', () => {
+		expect(board_source).toContain(String.raw`text_gameover.replace(' ', '\n')`)
+	})
+
+	it('shows the round as a large bare digit (no ROUND prefix, larger focal font)', () => {
+		expect(board_source).toContain('ROUND_DIGIT_FONT_SIZE')
+		expect(board_source).toContain('return String(game_data.round)')
+		// The stale pre-#137 form prefixed the digit with the ROUND label.
+		expect(board_source).not.toContain('text_round')
+	})
+
+	it('passes a per-state line height to the centre Text (multi-line spacing)', () => {
+		expect(board_source).toContain('lineHeight={current_line_height}')
+		expect(board_source).toContain('MULTILINE_LINE_HEIGHT')
+	})
+})
+
+describe('templates board-config scoreboard depth matches root (#267)', () => {
+	const ROOT_GAME_DIR = path.join(HERE, '..', 'src', 'lib', 'game')
+
+	function read_z_offset(directory: string): string {
+		const source = readFileSync(path.join(directory, 'board-config.ts'), 'utf8')
+		const value = /SCORE_DISPLAY_Z_OFFSET\s*=\s*([\d.]+)/u.exec(source)?.[1]
+		if (value === undefined) throw new Error('SCORE_DISPLAY_Z_OFFSET not found')
+
+		return value
+	}
+
+	it('keeps the template SCORE_DISPLAY_Z_OFFSET aligned with the root value', () => {
+		expect(read_z_offset(TEMPLATES_GAME_DIR)).toBe(read_z_offset(ROOT_GAME_DIR))
+	})
+})
+
 describe('templates/src/lib/game content shape (regression for #178)', () => {
 	it('does not ship a placeholder game-name.ts (game identity must flow from the generated game-config.ts)', () => {
 		const game_name_path = path.join(TEMPLATES_GAME_DIR, 'game-name.ts')

--- a/templates/src/lib/game/Board.svelte
+++ b/templates/src/lib/game/Board.svelte
@@ -22,7 +22,18 @@
 	const BACKING_RADIUS = 0.85
 	const CENTER_RADIUS = 0.22
 	const BACKING_Z = -0.01
-	const FONT_SIZE = 0.08
+	const FONT_SIZE = 0.13
+	// Per-line size used by GAME OVER (the only multi-line center label).
+	// Two short stacked lines have more horizontal room than the single-line layout, so the
+	// per-line size can be bumped above the single-line FONT_SIZE without overflowing the board.
+	const MULTILINE_FONT_SIZE = 0.16
+	// Large size for the digit-only ROUND display: a single number reads well at high size
+	// and is the focal information during play.
+	const ROUND_DIGIT_FONT_SIZE = 0.2
+	// Multiplier (relative to fontSize) used as Troika Text's lineHeight on GAME OVER so the
+	// two stacked lines have a little breathing room rather than sitting flush together.
+	const MULTILINE_LINE_HEIGHT = 1.4
+	const SINGLE_LINE_HEIGHT = 1
 	const EMISSIVE_INTENSITY = 0.8
 	const CYBER_EMISSIVE_INTENSITY = 1.5
 
@@ -39,7 +50,6 @@
 		game_data: GameBoardData
 		is_alt: boolean
 		text_gameover: string
-		text_round: string
 		text_start: string
 	}
 
@@ -78,7 +88,7 @@
 		},
 	] as const satisfies ReadonlyArray<ButtonConfig>
 
-	const { game_data, is_alt, text_gameover, text_round, text_start }: Props = $props()
+	const { game_data, is_alt, text_gameover, text_start }: Props = $props()
 
 	function is_lit(color: ButtonColor): boolean {
 		return (
@@ -97,12 +107,20 @@
 	}
 
 	function get_center_text(): string {
-		if (game_data.phase === 'gameover') return text_gameover
-		if (game_data.round > 0) return `${text_round} ${String(game_data.round)}`
+		if (game_data.phase === 'gameover') return text_gameover.replace(' ', '\n')
+		if (game_data.round > 0) return String(game_data.round)
 
 		return text_start
 	}
 
+	function get_center_base_font_size(): number {
+		if (game_data.phase === 'gameover') return MULTILINE_FONT_SIZE
+		if (game_data.round > 0) return ROUND_DIGIT_FONT_SIZE
+
+		return FONT_SIZE
+	}
+
+	const is_multiline_center = $derived(game_data.phase === 'gameover')
 	const center_text = $derived(get_center_text())
 	const emissive_intensity = $derived(
 		(is_alt ? CYBER_EMISSIVE_INTENSITY : EMISSIVE_INTENSITY) * game_data.flash_intensity,
@@ -110,8 +128,12 @@
 	// Font is driven by CRT state, independent of is_alt (CYBER) palette.
 	const should_use_alt_font = $derived(!crt.is_crt_enabled)
 	const current_font = $derived(fonts.get_font(should_use_alt_font))
+	const center_base_font_size = $derived(get_center_base_font_size())
 	const current_font_size = $derived(
-		FONT_SIZE * fonts.get_font_size_multiplier(should_use_alt_font),
+		center_base_font_size * fonts.get_font_size_multiplier(should_use_alt_font),
+	)
+	const current_line_height = $derived(
+		is_multiline_center ? MULTILINE_LINE_HEIGHT : SINGLE_LINE_HEIGHT,
 	)
 </script>
 
@@ -163,6 +185,7 @@
 			text={center_text}
 			font={current_font}
 			fontSize={current_font_size}
+			lineHeight={current_line_height}
 			color="#ffffff"
 			anchorX="center"
 			anchorY="middle"

--- a/templates/src/lib/game/Scene.svelte
+++ b/templates/src/lib/game/Scene.svelte
@@ -57,7 +57,6 @@
 			{game_data}
 			{is_alt}
 			text_gameover={messages.game_gameover}
-			text_round={messages.game_round}
 			text_start={messages.game_start}
 		/>
 	{/snippet}

--- a/templates/src/lib/game/board-config.ts
+++ b/templates/src/lib/game/board-config.ts
@@ -1,5 +1,5 @@
 export const BOARD_Y = 1.2
 export const BOARD_Z = -4.8
 export const BOARD_LABEL_Z = 0.05
-export const SCORE_DISPLAY_Z_OFFSET = 0.15
+export const SCORE_DISPLAY_Z_OFFSET = 0.4
 export const SCORE_DISPLAY_Z = BOARD_Z + SCORE_DISPLAY_Z_OFFSET


### PR DESCRIPTION
closes #267

## Summary

Re-scoped from the original "generate templates from root" plan, which investigation proved infeasible: the published `@joshuafolkken/game-kit` API exposes curated namespaces (e.g. `credits_scroll.make_credits_scroll_bounds`) while the in-repo demo imports bare internal symbols (`make_credits_scroll_bounds` from `$lib/game-kit/scene/credits-config`) — different symbol shapes, not just paths, so no mechanical transform exists. Templates must stay hand-maintained; this PR makes silent drift impossible instead and fixes the concrete drift bug.

## Changes

- **Fix the Board #137 readability drift** in `templates/src/lib/game/Board.svelte` (the template was frozen at the #129 rename and never received #137): multi-line GAME OVER (`text_gameover.replace(' ', '\n')`), large bare round digit (`ROUND_DIGIT_FONT_SIZE`), per-state `lineHeight`. Removed the now-unused `text_round` prop from the Board and its caller `Scene.svelte`.
- **Align the scoreboard depth**: `templates/.../board-config.ts` `SCORE_DISPLAY_Z_OFFSET` `0.15` → `0.4` (matches root's #137 tuning).
- **Tripwire-guard 16 divergent template files** (Board, Scene, Game.svelte.ts, types, board-config, board-input, audio, credits, flash, +page, +layout, +page.ts, hooks.server.ts, messages, app.html, vite.config.ts) as `TRIPWIRE_PAIRS` in `scripts/template-source-logic.ts`. A root-source edit now trips `reconcile-templates --check` (lefthook + CI), forcing a conscious manual re-port — the next "#137-class" drift cannot ship silently.
- **Regression tests**: assert the template Board has the #137 markers, and that the scoreboard `SCORE_DISPLAY_Z_OFFSET` stays aligned with root.

## Verification

lint / tsc / cspell / unit (1099 passed) all green; `reconcile-templates --check` in sync; code-review clean. The Board readability change was manually verified in a scaffolded project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
