### PR TITLE
jgame init: scaffold example e2e at src/routes/page.e2e.ts instead of tests/ #327

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.153.0",
+	"version": "0.154.0",
 	"keywords": [
 		"svelte"
 	],

--- a/scripts/init/jgame-init.test.ts
+++ b/scripts/init/jgame-init.test.ts
@@ -456,6 +456,8 @@ describe('jgame_init.run', () => {
 		expect(filter('/pkg/templates/tsconfig.json', '/project/tic-tac-toe/tsconfig.json')).toBe(false)
 		expect(filter('/pkg/templates/npmrc', '/project/tic-tac-toe/npmrc')).toBe(false)
 		expect(filter('/pkg/templates/src/app.html', '/project/tic-tac-toe/src/app.html')).toBe(true)
+		// The example e2e must land at src/routes/page.e2e.ts in a fresh init (#327).
+		expect(filter('/pkg/templates/src/routes/page.e2e.ts', '/project/x/page.e2e.ts')).toBe(true)
 	})
 
 	it('writes .npmrc from templates/npmrc to bypass npm dotfile exclusion', async () => {

--- a/scripts/templates/templates-content.test.ts
+++ b/scripts/templates/templates-content.test.ts
@@ -167,6 +167,26 @@ describe('templates/vite.config.ts ships the vitest test config required by josh
 	})
 })
 
+describe('templates ship a co-located example e2e (regression for #327)', () => {
+	const example_e2e_path = path.join(TEMPLATES_DIR, 'src', 'routes', 'page.e2e.ts')
+
+	it('provides the example e2e at src/routes/page.e2e.ts, co-located with the route', () => {
+		expect(existsSync(example_e2e_path)).toBe(true)
+	})
+
+	it('defines runnable playwright tests matched by the *.e2e.ts testMatch convention', () => {
+		const example_e2e_source = readFileSync(example_e2e_path, 'utf8')
+
+		expect(example_e2e_source).toContain("from '@playwright/test'")
+		expect(example_e2e_source).toContain('test(')
+	})
+
+	it('ships no top-level tests/ directory, so jgame init cannot scaffold one', () => {
+		// Pre-0.144 inits scaffolded tests/home.e2e.ts; the co-located form replaces it.
+		expect(existsSync(path.join(TEMPLATES_DIR, 'tests'))).toBe(false)
+	})
+})
+
 describe('.gitignore ignores generated .svelte-kit at any depth (regression for #296)', () => {
 	const gitignore_source = readFileSync(path.join(REPO_ROOT, '.gitignore'), 'utf8')
 

--- a/templates/src/routes/page.e2e.ts
+++ b/templates/src/routes/page.e2e.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+// Minimal example e2e scaffolded into every new game project (#327). Co-located
+// with the route it covers (src/routes/page.e2e.ts), matching the reference
+// project layout — playwright's `testMatch: '**/*.e2e.{ts,js}'` discovers it
+// regardless of directory. It also runs in game-kit's own CI (templates/ is not
+// test-ignored), which keeps the shipped example permanently green.
+const SEL_GAME_SCENE = '[data-testid="game-scene"]'
+
+test('home page shows the game scene', async ({ page }) => {
+	await page.goto('/')
+	await expect(page.locator(SEL_GAME_SCENE)).toBeVisible()
+})
+
+test('game scene renders a canvas', async ({ page }) => {
+	await page.goto('/')
+	await expect(page.locator(`${SEL_GAME_SCENE} canvas`)).toBeVisible()
+})


### PR DESCRIPTION
closes #327