### PR TITLE
Fix the controls hint panel shrinking below the viewport width on narrow viewports #412

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@joshuafolkken/game-kit",
-	"version": "0.196.0",
+	"version": "0.197.0",
 	"keywords": [
 		"svelte"
 	],

--- a/src/lib/game-kit/controls/ControlsScene.svelte
+++ b/src/lib/game-kit/controls/ControlsScene.svelte
@@ -6,6 +6,7 @@
 	import { controls_hint_adjust } from '$lib/game-kit/controls/controls-hint-adjust'
 	import { crt } from '$lib/game-kit/Crt.svelte'
 	import { fonts } from '$lib/game-kit/fonts'
+	import { camera_fov } from '$lib/game-kit/player/camera-fov'
 	import { onMount } from 'svelte'
 	import { BackSide, CanvasTexture, DoubleSide, FrontSide, NearestFilter } from 'three'
 
@@ -143,7 +144,13 @@
 		controls_hint_adjust.offset_position_y(0, hint_font_y_offset, hint_font_size),
 	)
 	const viewport_aspect = $derived($size.width / $size.height)
-	const view_width_at_plane = $derived(TOUCH_VIEW_HEIGHT_AT_PLANE * viewport_aspect)
+	// Not the plane height scaled by the aspect ratio: that assumes a fixed vertical FOV, which
+	// game-kit#276 ended. The camera widens its vertical FOV on portrait to hold the horizontal FOV,
+	// so below aspect 1 the view width stops shrinking — and the shortcut under-reported it by
+	// roughly the aspect ratio, scaling this panel to about half its fitting size (game-kit#412).
+	const view_width_at_plane = $derived(
+		camera_fov.compute_view_width_at_plane(TOUCH_VIEW_HEIGHT_AT_PLANE, viewport_aspect),
+	)
 	const touch_world_width = $derived(view_width_at_plane * TOUCH_WIDTH_RATIO)
 	const touch_world_height = $derived(touch_world_width / TOUCH_SVG_ASPECT)
 	const pc_scale = $derived(

--- a/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
+++ b/src/lib/game-kit/controls/ControlsScene.svelte.test.ts
@@ -179,6 +179,19 @@ describe('ControlsScene PC icon fit — keyboard and mouse must not overflow the
 		)
 	})
 
+	// game-kit#412: the width fed to compute_fit_scale must come from the module that owns the
+	// camera FOV. Deriving it here as view_height * aspect is the pre-#276 framing model and
+	// under-reports the width on portrait, scaling the panel to about half the size that fits.
+	it('takes the view width from camera_fov rather than multiplying a fixed height by the aspect', () => {
+		expect(SOURCE).toContain(
+			'camera_fov.compute_view_width_at_plane(TOUCH_VIEW_HEIGHT_AT_PLANE, viewport_aspect)',
+		)
+		expect(SOURCE).not.toMatch(/TOUCH_VIEW_HEIGHT_AT_PLANE\s*\*\s*viewport_aspect/u)
+		expect(SOURCE).toMatch(
+			/import\s*\{\s*camera_fov\s*\}\s*from\s*'\$lib\/game-kit\/player\/camera-fov'/u,
+		)
+	})
+
 	it('compute_fit_scale is imported from the controls-fit helper module', () => {
 		expect(SOURCE).toMatch(
 			/import\s*\{\s*compute_fit_scale\s*\}\s*from\s*'\$lib\/game-kit\/controls\/controls-fit'/u,

--- a/src/lib/game-kit/controls/controls-fit.test.ts
+++ b/src/lib/game-kit/controls/controls-fit.test.ts
@@ -1,3 +1,4 @@
+import { camera_fov } from '$lib/game-kit/player/camera-fov'
 import { describe, expect, it } from 'vitest'
 import { compute_fit_scale } from './controls-fit'
 
@@ -64,5 +65,44 @@ describe('compute_fit_scale', () => {
 
 			expect(headroom).toBeGreaterThanOrEqual(-1e-10)
 		}
+	})
+})
+
+// Regression for game-kit#412. ControlsScene fed this function `view_height * aspect`, which is the
+// pre-#276 framing model; on portrait that under-reports the view width by roughly the aspect ratio
+// and the panel came out around half the size that fits. These are the real constants from
+// ControlsScene, so the numbers are the ones the screen actually uses.
+const CONTROLS_PLANE_HEIGHT = 2.45
+const CONTROLS_NATURAL_SPAN = 1.815
+const CONTROLS_SIDE_PADDING = 0.138
+const PORTRAIT_ASPECT = 480 / 900
+
+describe('controls panel fit on a portrait viewport (game-kit#412)', () => {
+	it('does not shrink the panel at a phone aspect ratio', () => {
+		const view_width = camera_fov.compute_view_width_at_plane(
+			CONTROLS_PLANE_HEIGHT,
+			PORTRAIT_ASPECT,
+		)
+
+		expect(compute_fit_scale(view_width, CONTROLS_NATURAL_SPAN, CONTROLS_SIDE_PADDING)).toBe(1)
+	})
+
+	it('would have shrunk it under the pre-#276 framing model — the bug this pins', () => {
+		// Kept as the counter-example so the test above cannot be satisfied by loosening the fit
+		// function instead of fixing the width it is given.
+		const shortcut_width = CONTROLS_PLANE_HEIGHT * PORTRAIT_ASPECT
+
+		expect(
+			compute_fit_scale(shortcut_width, CONTROLS_NATURAL_SPAN, CONTROLS_SIDE_PADDING),
+		).toBeLessThan(1)
+	})
+
+	it('still shrinks the panel when the viewport is genuinely too narrow', () => {
+		const EXTREME_ASPECT = 0.2
+		const view_width = camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, EXTREME_ASPECT)
+
+		expect(
+			compute_fit_scale(view_width, CONTROLS_NATURAL_SPAN, CONTROLS_SIDE_PADDING),
+		).toBeLessThan(1)
 	})
 })

--- a/src/lib/game-kit/player/Player.svelte
+++ b/src/lib/game-kit/player/Player.svelte
@@ -12,7 +12,6 @@
 	const SPAWN_Y = 1
 	const SPAWN_Z = 3
 	const HEAD_HEIGHT = 0.6
-	const FOV = 75
 	const NEAR_PLANE = 0.1
 	const FAR_PLANE = 50
 	const JOYSTICK_LOOK_SPEED = 2
@@ -33,7 +32,9 @@
 	// via the reactive $size store (not the non-reactive .current accessor) re-derives this on
 	// resize / orientation change.
 	const { size } = useThrelte()
-	const vertical_fov = $derived(camera_fov.compute_vertical_fov(FOV, $size.width / $size.height))
+	const vertical_fov = $derived(
+		camera_fov.compute_vertical_fov(camera_fov.BASE_FOV_DEG, $size.width / $size.height),
+	)
 
 	let pos_x = $state(SPAWN_X)
 	let pos_y = $state(SPAWN_Y)

--- a/src/lib/game-kit/player/Player.svelte.test.ts
+++ b/src/lib/game-kit/player/Player.svelte.test.ts
@@ -170,10 +170,14 @@ describe('Player', () => {
 })
 
 describe('Player camera FOV — horizontal-FOV-aware on portrait viewports', () => {
-	it('derives the vertical FOV via camera_fov.compute_vertical_fov(FOV, aspect)', () => {
+	// The base FOV moved into camera-fov.ts with game-kit#412: the controls scene needs the same
+	// value to size itself against the camera, and a local literal here would be a second copy to
+	// keep in step with the portrait rule.
+	it('derives the vertical FOV via camera_fov.compute_vertical_fov with the shared base FOV', () => {
 		expect(PLAYER_SOURCE).toMatch(
-			/vertical_fov\s*=\s*\$derived\(\s*camera_fov\.compute_vertical_fov\(\s*FOV\s*,/u,
+			/vertical_fov\s*=\s*\$derived\(\s*camera_fov\.compute_vertical_fov\(\s*camera_fov\.BASE_FOV_DEG\s*,/u,
 		)
+		expect(PLAYER_SOURCE).not.toMatch(/const\s+FOV\s*=\s*75/u)
 	})
 
 	it('subscribes to the Threlte size store via $size so the FOV reacts to resize', () => {

--- a/src/lib/game-kit/player/camera-fov.test.ts
+++ b/src/lib/game-kit/player/camera-fov.test.ts
@@ -58,3 +58,68 @@ describe('camera_fov.compute_vertical_fov', () => {
 		expect(camera_fov.compute_vertical_fov(BASE_FOV, NaN)).toBe(BASE_FOV)
 	})
 })
+
+// The controls-plane view height at the base FOV, as ControlsScene measures it.
+const CONTROLS_PLANE_HEIGHT = 2.45
+const PRECISION = 6
+
+describe('camera_fov.compute_view_width_at_plane', () => {
+	it('exposes the base FOV so no consumer has to repeat the literal', () => {
+		expect(camera_fov.BASE_FOV_DEG).toBe(BASE_FOV)
+	})
+
+	it('is height * aspect in landscape, exactly as a fixed vertical FOV would give', () => {
+		const WIDE_ASPECT = 16 / 9
+
+		expect(camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, WIDE_ASPECT)).toBeCloseTo(
+			CONTROLS_PLANE_HEIGHT * WIDE_ASPECT,
+			PRECISION,
+		)
+	})
+
+	it('is unchanged at the square boundary, where the portrait rule starts', () => {
+		expect(camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, 1)).toBeCloseTo(
+			CONTROLS_PLANE_HEIGHT,
+			PRECISION,
+		)
+	})
+
+	// This is the property game-kit#412 turned on: holding the horizontal FOV constant means the
+	// view width at any plane stops moving once the viewport goes portrait. Reporting
+	// height * aspect here instead under-reported it by the aspect ratio.
+	it('holds the width constant across portrait aspects above the FOV cap', () => {
+		const SQUARE_WIDTH = camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, 1)
+
+		for (const aspect of [0.9, 0.75, 0.6, 0.5, 0.45]) {
+			expect(camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, aspect)).toBeCloseTo(
+				SQUARE_WIDTH,
+				PRECISION,
+			)
+		}
+	})
+
+	it('starts shrinking again once the vertical FOV hits its cap', () => {
+		// Past the cap the vertical FOV can no longer widen, so the horizontal FOV — and with it the
+		// width — falls with the aspect again. Without this the panel would be sized for a view
+		// wider than the camera actually shows on an extremely tall viewport.
+		const SQUARE_WIDTH = camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, 1)
+		const CAPPED = camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, 0.3)
+		const NARROWER = camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, 0.2)
+
+		expect(CAPPED).toBeLessThan(SQUARE_WIDTH)
+		expect(NARROWER).toBeLessThan(CAPPED)
+	})
+
+	it('never reports a wider view than the camera shows at the capped FOV', () => {
+		const NARROW_ASPECT = 0.25
+		const capped_half_tan = Math.tan(camera_fov.MAX_VERTICAL_FOV_DEG / HALF_DIVISOR / DEG_PER_RAD)
+		const base_half_tan = Math.tan(BASE_FOV / HALF_DIVISOR / DEG_PER_RAD)
+
+		expect(
+			camera_fov.compute_view_width_at_plane(CONTROLS_PLANE_HEIGHT, NARROW_ASPECT),
+		).toBeCloseTo(
+			(CONTROLS_PLANE_HEIGHT * capped_half_tan * NARROW_ASPECT) / base_half_tan,
+			PRECISION,
+		)
+	})
+})

--- a/src/lib/game-kit/player/camera-fov.ts
+++ b/src/lib/game-kit/player/camera-fov.ts
@@ -7,6 +7,13 @@ const LANDSCAPE_ASPECT = 1
 // phones sit near aspect 0.46 (~118° here), so the cap only engages for pathological aspects.
 const MAX_VERTICAL_FOV_DEG = 120
 const DEG_PER_RAD = STRAIGHT_ANGLE_DEG / Math.PI
+const BASE_FOV_DEG_VALUE = 75
+
+// The camera's vertical FOV in landscape, and the reference every derived framing number is
+// measured against. It lives here rather than in Player.svelte because the controls scene needs
+// the same value to work out how wide the camera's view is at its own plane (game-kit#412) —
+// a second copy of the literal would be a second thing to keep in step with the portrait rule.
+const BASE_FOV_DEG = BASE_FOV_DEG_VALUE
 
 // A fixed vertical FOV lets the *horizontal* FOV shrink with the aspect ratio, so on a
 // portrait viewport wide content (the title, side room content) is clipped at the frustum
@@ -25,4 +32,32 @@ function compute_vertical_fov(base_fov_deg: number, aspect: number): number {
 	return Math.min(vertical_fov_deg, MAX_VERTICAL_FOV_DEG)
 }
 
-export const camera_fov = { compute_vertical_fov, MAX_VERTICAL_FOV_DEG }
+function half_tan(fov_deg: number): number {
+	return Math.tan(fov_deg / HALF_DIVISOR / DEG_PER_RAD)
+}
+
+// How wide the camera's view is at a plane, given how tall that view is when the camera is at its
+// base FOV. Everything at a fixed distance scales with tan(fov / 2), so the height at the live FOV
+// is the base height times the ratio of the two tangents, and the width is that times the aspect.
+//
+// Consumers must not shortcut this as `base_height * aspect` (game-kit#412). That shortcut assumes
+// the vertical FOV never moves, which stopped being true in game-kit#276: on portrait the vertical
+// FOV widens to hold the horizontal FOV constant, so the view width stays PUT below aspect 1
+// instead of shrinking with it — until MAX_VERTICAL_FOV_DEG caps the widening and it shrinks again.
+// Reading the FOV back through compute_vertical_fov gets all three regimes for free.
+//
+// Landscape is unchanged by construction: compute_vertical_fov returns the base FOV at aspect >= 1,
+// so the ratio is 1 and this is exactly `base_height * aspect`.
+function compute_view_width_at_plane(base_view_height: number, aspect: number): number {
+	const vertical_fov = compute_vertical_fov(BASE_FOV_DEG_VALUE, aspect)
+	const height_scale = half_tan(vertical_fov) / half_tan(BASE_FOV_DEG_VALUE)
+
+	return base_view_height * height_scale * aspect
+}
+
+export const camera_fov = {
+	compute_vertical_fov,
+	compute_view_width_at_plane,
+	MAX_VERTICAL_FOV_DEG,
+	BASE_FOV_DEG,
+}


### PR DESCRIPTION
closes #412